### PR TITLE
Close #184

### DIFF
--- a/deeptrack/generators.py
+++ b/deeptrack/generators.py
@@ -363,7 +363,7 @@ class ContinuousGenerator(keras.utils.Sequence):
                 np.array(labels),
             )
         else:
-            return np.array(data), np.array(labels)
+            return np.array(data, dtype=object), np.array(labels, dtype=object)
 
     def __len__(self):
         steps = int((self.min_data_size // self._batch_size))

--- a/deeptrack/image.py
+++ b/deeptrack/image.py
@@ -314,7 +314,7 @@ class Image:
 
     def __array__(self, *args, **kwargs):
         """Convert to numpy array."""
-        return np.array(self.to_numpy()._value)
+        return np.array(self.to_numpy()._value, *args)
 
     def to_tf(self):
         """Convert to tensorflow tensor."""

--- a/deeptrack/models/gnns/generators.py
+++ b/deeptrack/models/gnns/generators.py
@@ -188,7 +188,7 @@ class ContinuousGraphGenerator(ContinuousGenerator):
             # Clips node and edge solutions
             nodesol = labels[i][0][:cropTo]
             edgesol = labels[i][1][~edge_dropouts]
-            globsol = labels[i][2].astype(np.float)
+            globsol = labels[i][2].astype(float)
 
             inputs[0].append(nodef)
             inputs[1].append(edgef)

--- a/deeptrack/test/test_generators.py
+++ b/deeptrack/test/test_generators.py
@@ -187,5 +187,55 @@ class TestGenerators(unittest.TestCase):
         )
         self.assertIsInstance(generator, gnns.generators.ContinuousGraphGenerator)
 
+
+    def test_training(self):
+        from deeptrack.extras import datasets
+        import tensorflow as tf
+
+        datasets.load("BFC2Cells")
+        nodesdf = pd.read_csv("datasets/BFC2DLMuSCTra/nodesdf.csv")
+
+        # normalize centroids between 0 and 1
+        nodesdf.loc[:, nodesdf.columns.str.contains("centroid")] = (
+            nodesdf.loc[:, nodesdf.columns.str.contains("centroid")]
+            / np.array([1000.0, 1000.0])
+        )
+        parenthood = pd.read_csv("datasets/BFC2DLMuSCTra/parenthood.csv")
+        variables = features.DummyFeature(
+            radius=0.2,
+            output_type="edges",
+            nofframes=3, # time window to associate nodes (in frames)
+        )
+        model = gnns.MAGIK(
+            dense_layer_dimensions=(64, 96,),      # number of features in each dense encoder layer
+            base_layer_dimensions=(96, 96, 96),    # Latent dimension throughout the message passing layers
+            number_of_node_features=2,             # Number of node features in the graphs
+            number_of_edge_features=1,             # Number of edge features in the graphs
+            number_of_edge_outputs=1,              # Number of predicted features
+            edge_output_activation="sigmoid",      # Activation function for the output layer
+            output_type="edges",              # Output type. Either "edges", "nodes", or "graph"
+        )
+
+        # Compile model
+        model.compile(
+            optimizer=tf.keras.optimizers.Adam(learning_rate=0.001),
+            loss = 'binary_crossentropy',
+            metrics=['accuracy'],
+        )
+
+        generator = gnns.generators.GraphGenerator(
+                nodesdf=nodesdf,
+                properties=["centroid"],
+                parenthood=parenthood,
+                min_data_size=8,#511,
+                max_data_size=9,#512,
+                batch_size=8,
+                **variables.properties()
+            )
+        
+        with generator:
+            model.fit(generator, epochs=1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR should fix the issue of MAGIK notebook not running with NumPy=>1.24 due to the expired deprecation from NumPy=1.24 of the ragged array creation and deprecation of built-in type aliases in NumPy=1.20.