### PR TITLE
typo fix

### DIFF
--- a/tutorials/4-developers/DTDV401_overview.ipynb
+++ b/tutorials/4-developers/DTDV401_overview.ipynb
@@ -40,7 +40,7 @@
    "source": [
     "## 2. Module Structure\n",
     "\n",
-    "Each module should be cleraly documented in the beginning.\n",
+    "Each module should be clearly documented in the beginning.\n",
     "\n",
     "Often modules contain some **abstract** classes to provide a standardized implementation of core functionality (for example, image transformation) to ensure consistent output formatting across all derived classes in the module (for instance, to ensure that the format of the output image is the same).\n",
     "\n",
@@ -278,7 +278,7 @@
    "metadata": {},
    "source": [
     "### 9.3. Deeplay\n",
-    "The init file in [deeplay/__init__.py](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/deeptrack/deeplay/__init__.py) enables users to import Deeplay from DeepTrack2 with:\n",
+    "The init file in [deeplay/\\_\\_init__.py](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/deeptrack/deeplay/__init__.py) enables users to import Deeplay from DeepTrack2 with:\n",
     "\n",
     "```python \n",
     "import deeptrack.deeplay as dl\n",


### PR DESCRIPTION
typo fix and changed "deeptrack/__init__" to now render as deeptrack/\_\_init__ in markdown.