### PR TITLE
DeepTrack 1.7, links and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ We have two separate series of notebooks which aims to teach you all you need to
 The second series focuses on individual topics, introducing them in a natural order. 
 
 1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Introducing how to create simulation pipelines and train models. </a>
-2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/02.%20using_deeptrack_generators.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Demonstrating data generators. </a> 
 
 ## DeepTrack 2.1 in action
 

--- a/README.md
+++ b/README.md
@@ -91,16 +91,12 @@ Everybody learns in different ways! Depending on your preferences, and what you 
 
 ## Getting-started guides
 
-We have two separate series of notebooks which aims to teach you all you need to know to use DeepTrack to its fullest. The first is a set of six notebooks with a focus on the application.
-
+We have a set of notebooks which aims to teach you all you need to know to use DeepTrack to its fullest, which consists of four notebooks with a focus on the application.
 
 1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/01.%20tracking_particle_cnn_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_cnn_tutorial </a> demonstrates how to track a point particle with a convolutional neural network (CNN).
 2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/02.%20tracking_multiple_particles_unet_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_unet_tutorial </a> demonstrates how to track multiple particles using a U-net.
 3. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/03.%20distinguishing_particles_in_brightfield_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> distinguishing_particles_in_brightfield_tutorial </a> demonstrates how to use a U-net to track and distinguish particles of different sizes in brightfield microscopy. 
-
-The second series focuses on individual topics, introducing them in a natural order. 
-
-1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Introducing how to create simulation pipelines and train models. </a>
+4. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Introducing how to create simulation pipelines and train models. </a>
 
 ## DeepTrack 2.1 in action
 

--- a/README.md
+++ b/README.md
@@ -1,312 +1,172 @@
-<!-- GH_ONLY_START -->
 <p align="center">
-  <img width="350" src=https://github.com/DeepTrackAI/DeepTrack2/blob/develop/assets/DeepTrack2-logo.png?raw=true>
+  <img width="350" src=https://github.com/softmatterlab/DeepTrack2/blob/1.7/assets/logo.png?raw=true>
 </p>
-<!-- GH_ONLY_END -->
 
-<h3 align="center">DeepTrack2 - A comprehensive deep learning framework for digital microscopy.</h3>
+<h3 align="center">A comprehensive deep learning framework for digital microscopy.</h3>
 <p align="center">
-  <a href="/LICENSE" alt="licence">
-    <img src="https://img.shields.io/github/license/DeepTrackAI/DeepTrack2">
-  </a>
-  <a href="https://badge.fury.io/py/deeptrack">
-    <img src="https://badge.fury.io/py/deeptrack.svg" alt="PyPI version">
-  </a>
-  <a href="https://deeptrackai.github.io/DeepTrack2">
-    <img src="https://img.shields.io/badge/docs-available-blue?logo=readthedocs">
-  </a>
-  <a href="https://badge.fury.io/py/deeptrack">
-    <img src="https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue" alt="Python version">
-  </a>
-  <a href="https://doi.org/10.1063/5.0034891">
-    <img src="https://img.shields.io/badge/cite us-10.1063%2F5.0034891-blue">
+  <a href="/LICENSE" alt="licence"><img src="https://img.shields.io/github/license/softmatterlab/DeepTrack-2.0"></a>
+  <a href="https://badge.fury.io/py/deeptrack"><img src="https://badge.fury.io/py/deeptrack.svg" alt="PyPI version"></a>
+  <a href="https://deeptrackai.github.io/DeepTrack2"><img src="https://img.shields.io/badge/docs-passing-green" alt="PyPI version"></a>
+  <a href="https://badge.fury.io/py/deeptrack"><img src="https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue" alt="Python version"></a>
+  <a href="https://doi.org/10.1063/5.0034891" alt="DOI">
+    <img src="https://img.shields.io/badge/DOI-10.1063%2F5.0034891-blue">
   </a>
 </p>
 <p align="center">
   <a href="#installation">Installation</a> •
-  <a href="#getting-started">Getting Started</a> •
-  <a href="#examples">Examples</a> •
-  <a href="#advanced-tutorials">Advanced Tutorials</a> •
-  <a href="#developer-tutorials">Developer Tutorials</a> •
+  <a href="#examples-of-applications-using-deeptrack">Examples</a> •
+  <a href="#getting-started-guides">Basics</a> •
   <a href="#cite-us">Cite us</a> •
   <a href="/LICENSE">License</a> 
 </p>
 
-DeepTrack2 is a modular Python library for generating, manipulating, and analyzing image data pipelines for machine learning and experimental imaging.
 
-<b>TensorFlow Compatibility Notice:</b> 
-DeepTrack2 version 2.0 and subsequent do not support TensorFlow. If you need TensorFlow support, please install the legacy version 1.7.
-
-The following quick start guide is intended for complete beginners to understand how to use DeepTrack2, from installation to training your first model. Let's get started!
+We provide tools to create physical simulations of optical systems, to generate and train neural network models, and to analyze experimental data.
 
 # Installation
 
-DeepTrack2 2.0 requires at least python 3.9.
+DeepTrack 2.1 requires at least python 3.6.
 
-To install DeepTrack2, open a terminal or command prompt and run:
-```bash
-pip install deeptrack
+To install DeepTrack 2.1, open a terminal or command prompt and run:
+
+    pip install deeptrack
+    
+If you have a very recent version of python, you may need to install numpy _before_ DeepTrack. This is a known issue with scikit-image.
+
+### Updating to 2.1 from 2.0
+
+If you are already using DeepTrack 2.0 (pypi version 0.x.x), updating to DeepTrack 2.1 (pypi version 1.x.x) is painless. If you have followed deprecation warnings, no change to your code is needed. There are two breaking changes:
+
+- The deprecated operator `+` to chain features has been removed. It is now only possible using the `>>` operator.
+- The deprecated operator `**` to duplicate a feature has been removed. It is now only possible using the `^` operator.
+
+If you notice any other changes in behavior, please report it to us in the issues tab.
+
+# Examples of applications using DeepTrack 
+
+DeepTrack is a general purpose deep learning framework for microscopy, meaning you can use it for any task you like. Here, we show some common applications!
+
+<br/>
+<h3 align="left"> Single particle tracking </h3>
+<p align="left">
+  <img width="300" src=/assets/SPT-ideal.gif?raw=true>
+  <img width="300" src=/assets/SPT-noisy.gif?raw=true>
+  <br/>
+  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/paper-examples/2-single_particle_tracking.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training a CNN-based single particle tracker using simulated data </a>
+  <br/>
+  <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="DOI lodestar">
+    <img src="https://img.shields.io/badge/DOI-10.1038%2Fs41467--022--35004--y-blue">
+  </a> 
+  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/LodeSTAR/02.%20tracking_particles_of_various_shapes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Unsupervised training of a single particle tracker using LodeSTAR </a> 
+  
+</p>
+<br/>
+
+<h3 align="left"> Multi-particle tracking </h3>
+
+<p align="left">
+  <img width="600" src=/assets/MPT-packed.gif?raw=true>
+  <br/>
+  <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="DOI lodestar">
+    <img src="https://img.shields.io/badge/DOI-10.1038%2Fs41467--022--35004--y-blue">
+  </a> <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/LodeSTAR/03.track_BF-C2DL-HSC.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training LodeSTAR to detect multiple cells from a single image </a>
+  <br/>
+  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/paper-examples/4-multi-molecule-tracking.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training a UNet-based multi-particle tracker using simulated data </a> 
+</p>
+<br/>
+
+<h3 align="left"> Particle tracing </h3>
+
+<p align="left">
+  <img width="600" src=/assets/Tracing.gif?raw=true>
+  <br/>
+  <a href="https://doi.org/10.48550/arXiv.2202.06355" alt="DOI magik">
+    <img src="https://img.shields.io/badge/DOI-10.48550%2FarXiv.2202.0635-blue">
+  </a>  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/MAGIK/cell_migration_analysis.ipynb"> <img     src="https://colab.research.google.com/assets/colab-badge.svg"> Training MAGIK to trace migrating cells </a>
+</p>
+
+# Basics to learn DeepTrack 2.1
+
+Everybody learns in different ways! Depending on your preferences, and what you want to do with DeepTrack, you may want to check out one or more of these resources.
+
+## Getting-started guides
+
+We have two separate series of notebooks which aims to teach you all you need to know to use DeepTrack to its fullest. The first is a set of six notebooks with a focus on the application.
+
+
+1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/01.%20tracking_particle_cnn_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_cnn_tutorial </a> demonstrates how to track a point particle with a convolutional neural network (CNN).
+2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/02.%20tracking_multiple_particles_unet_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_unet_tutorial </a> demonstrates how to track multiple particles using a U-net.
+3. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/tutorials/03.%20distinguishing_particles_in_brightfield_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> distinguishing_particles_in_brightfield_tutorial </a> demonstrates how to use a U-net to track and distinguish particles of different sizes in brightfield microscopy. 
+
+The second series focuses on individual topics, introducing them in a natural order. 
+
+1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Introducing how to create simulation pipelines and train models. </a>
+2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/1.7/examples/get-started/02.%20using_deeptrack_generators.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Demonstrating data generators. </a> 
+
+## DeepTrack 2.1 in action
+
+Additionally, we have seven more case studies which are less documented, but gives additional insight in how to use DeepTrack with real datasets
+
+1. [MNIST](examples/paper-examples/1-MNIST.ipynb) classifies handwritted digits.
+2. [single particle tracking](examples/paper-examples/2-single_particle_tracking.ipynb) tracks experimentally captured videos of a single particle. (Requires opencv-python compiled with ffmpeg to open and read a video.)
+3. [single particle sizing](examples/paper-examples/3-particle_sizing.ipynb) extracts the radius and refractive index of particles.
+4. [multi-particle tracking](examples/paper-examples/4-multi-molecule-tracking.ipynb) detects quantum dots in a low SNR image.
+5. [3-dimensional tracking](examples/paper-examples/5-inline_holography_3d_tracking.ipynb) tracks particles in three dimensions.
+6. [cell counting](examples/paper-examples/6-cell_counting.ipynb) counts the number of cells in fluorescence images.
+7. [GAN image generation](examples/paper-examples/7-GAN_image_generation.ipynb) uses a GAN to create cell image from masks.
+
+## Model-specific examples
+
+We also have examples that are specific for certain models. This includes 
+- [*LodeSTAR*](examples/LodeSTAR) for label-free particle tracking.
+- [*MAGIK*](examples/MAGIK) for graph-based particle linking and trace characterization.
+
+## Documentation
+The detailed documentation of DeepTrack 2.1 is available at the following link: https://deeptrackai.github.io/DeepTrack2
+
+## Video Tutorials
+
+Videos are currently being updated to match with the current version of DeepTrack.
+
+## Cite us!
+If you use DeepTrack 2.1 in your project, please cite us here:
+
 ```
-or
-```bash
-python -m pip install deeptrack
-```
-This will automatically install the required dependencies.
-
-# Getting Started
-
-Here you find a series of notebooks that give you an overview of the core features of DeepTrack2 and how to use them:
-
-- DTGS101 **[Introduction to DeepTrack2](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS101_intro.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS101_intro.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Overview of how to use DeepTrack 2. Creating images combining DeepTrack2 features, extracting properties, and using them to train a neural network.
-
-- DTGS111 **[Loading Image Files Using Sources](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS111_datafiles.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS111_datafiles.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Using sources to load image files and to train a neural network.
-
-- DTGS121 **[Tracking a Point Particle with a CNN](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS121_tracking_particle_cnn.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS121_tracking_particle_cnn.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Tracking a point particle with a convolutional neural network (CNN) using simulated images in the training process.
-
-- DTGS131 **[Tracking Multiple Particles with a U-Net](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS131_tracking_multiple_particles_unet.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS131_tracking_multiple_particles_unet.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Tracking multiple particles using a U-net trained on simulated images.
-
-- DTGS141 **[Distinguishing Particles with a U-Net](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS141_distinguishing_particles_in_brightfield.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS141_distinguishing_particles_in_brightfield.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Tracking and distinguishing particles of different sizes in brightfield microscopy using a U-net trained on simulated images.
-
-- DTGS151 **[Unsupervised Object Detection](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS151_unsupervised_object_detection_with_lodestar.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS151_unsupervised_object_detection_with_lodestar.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Single-shot unsupervised object detection a using LodeSTAR.
-
-# Examples
-
-These are examples of how DeepTrack2 can be used on real datasets:
-
-- DTEx211 **[MNIST](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx201_MNIST.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx201_MNIST.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-  Training a fully connected neural network to identify handwritten digits using MNIST dataset.
-
-- DTEx212 **Single Particle Tracking**
-
-  Tracks experimental videos of a single particle. (Requires opencv-python compiled with ffmpeg)
-
-  <!-- GH_ONLY_START -->
-  <p align="left">
-    <img width="300" src=/assets/SPT-ideal.gif?raw=true>
-    <img width="300" src=/assets/SPT-noisy.gif?raw=true>
-    <br/>
-    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx202_single_particle_tracking.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg">
-    </a>
-    <a href="https://doi.org/10.1364/OPTICA.6.000506" alt="DeepTrack article">
-      <img src="https://img.shields.io/badge/article-10.1364/OPTICA.6.000506-blue">
-    </a> 
-    <br/>
-    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx231B_LodeSTAR_tracking_particles_of_various_shapes.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg">
-    </a>
-    <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="LodeSTAR article">
-      <img src="https://img.shields.io/badge/article-10.1038%2Fs41467--022--35004--y-blue">
-    </a> 
-  </p>
-  <!-- GH_ONLY_END -->
-
-- DTEx213 **Multi-Particle tracking**
-- 
-  Detecting quantum dots in a low SNR image.
-
-  <!-- GH_ONLY_START -->
-  <p align="left">
-    <img width="600" src=/assets/MPT-packed.gif?raw=true>
-    <br/>
-    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx203_particle_sizing.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg">
-    </a>
-    <a href="https://doi.org/10.1063/5.0034891" alt="LodeSTAR article">
-      <img src="https://img.shields.io/badge/article-10.1063/5.0034891-blue">
-    </a> 
-    <br/>
-    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx231A_LodeSTAR_autotracker_template.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg">
-    </a>
-    <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="Article LodeSTAR">
-      <img src="https://img.shields.io/badge/article-10.1038%2Fs41467--022--35004--y-blue">
-    </a>
-  </p>
-  <!-- GH_ONLY_END -->
-
-- DTEx214 **Particle Feature Extraction**
-- 
-  Extracting the radius and refractive index of particles.
-
-- DTEx215 **Cell Counting**
-
-  Counting the number of cells in fluorescence images.
-
-- DTEx216 **3D Multi-Particle tracking**
-
-  Tracking multiple particles in 3D for holography.
-
-- DTEx217 **GAN image generation**
-
-  Using a GAN to create cell image from masks.
-
-Specific examples for label-free particle tracking using **LodeSTAR**:
-
-- DTEx231A **LodeSTAR Autotracker Template**
-
-- DTEx231B **LodeSTAR Detecting Particles of Various Shapes**
-
-- DTEx231C **LodeSTAR Measuring the Mass of Particles in Holography**
-
-- DTEx231D **LodeSTAR Detecting the Cells in the BF-C2DT-HSC Dataset**
-
-- DTEx231E **LodeSTAR Detecting the Cells in the Fluo-C2DT-Huh7 Dataset**
-  
-- DTEx231F **LodeSTAR Detecting the Cells in the PhC-C2DT-PSC Dataset**
-  
-- DTEx231G **LodeSTAR Detecting Plankton**
-  
-- DTEx231H **LodeSTAR Detecting in 3D Holography**
-
-- DTEx231I **LodeSTAR Measuring the Mass of Simulated Particles**
-  
-- DTEx231J **LodeSTAR Measuring the Mass of Cells**
-
-Specific examples for graph-neural-network-based particle linking and trace characterization using **MAGIK**:
-
-- DTEx241A **MAGIK Tracing Migrating Cells**
-
-  <!-- GH_ONLY_START -->
-  <p align="left">
-    <img width="600" src=/assets/Tracing.gif?raw=true>
-    <br/>
-    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx241A_MAGIK_cell_migration_analysis.ipynb">
-      <img src="https://colab.research.google.com/assets/colab-badge.svg">
-    </a>
-    <a href="https://doi.org/10.1038/s42256-022-00595-0" alt="Article MAGIK">
-      <img src="https://img.shields.io/badge/article-10.1038/s42256--022--00595--0-blue">
-    </a>  
-  </p>
-  <!-- GH_ONLY_END -->
-
-- DTEx241B **MAGIK to Track HeLa Cells**
-
-# Advanced Tutorials
-
-This section provides a list of advanced topic tutorials. The primary focus of these tutorials is to demonstrate the functionalities of individual modules and how they work in relative isolation, helping to provide a better understanding of them and their roles in DeepTrack2.
-
-- DTAT301 **[deeptrack.features](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT301_features.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT301_features.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT306 **[deeptrack.properties](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT306_properties.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT306_properties.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT311 **[deeptrack.image](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT311_image.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT311_image.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT321 **[deeptrack.scatterers](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT321_scatterers.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT321_scatterers.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT323 **[deeptrack.optics](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT323_optics.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT323_optics.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT324 **[deeptrack.holography](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT324_holography.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT324_holography.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT325 **[deeptrack.aberrations](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT325_aberrations.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT325_aberrations.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT327 **[deeptrack.noises](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT327_noises.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT327_noises.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT329 **[deeptrack.augmentations](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT329_augmentations.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT329_augmentations.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT341 **[deeptrack.sequences](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT341_sequences.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT341_sequences.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT381 **[deeptrack.math](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT381_math.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT381_math.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT383 **[deeptrack.utils](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT383_utils.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT383_utils.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTAT385 **[deeptrack.statistics](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT385_statistics.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT385_statistics.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT387 **[deeptrack.types](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT389 **[deeptrack.elementwise](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT389_elementwise.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT389_elementwise.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT391A **[deeptrack.sources.base](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391A_sources.base.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391A_sources.base.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT391B **[deeptrack.sources.folder](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391B_sources.folder.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391B_sources.folder.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT391C **[deeptrack.sources.rng](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391C_sources.rng.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391C_sources.rng.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT393A **[deeptrack.pytorch.data](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393A_pytorch.features.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393A_pytorch.features.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT393B **[deeptrack.pytorch.features](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393B_pytorch.data.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393B_pytorch.data.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT395 **[deeptrack.extras.radialcenter](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT395_extras.radialcenter.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT395_extras.radialcenter.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-- DTAT399A **[deeptrack.backend.core](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399A_backend.core.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399A_backend.core.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-  
-- DTAT399B **[deeptrack.backend.pint_definition](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399B_backend.pint_definition.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399B_backend.pint_definition.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-  
-- DTAT399C **[deeptrack.backend.units](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399C_backend.units.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399C_backend.units.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-  
-- DTAT399D **[deeptrack.backend.polynomials](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399D_backend.polynomials.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399D_backend.polynomials.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-  
-- DTAT399E **[deeptrack.backend.mie](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399E_backend.mie.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399E_backend.mie.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-  
-- DTAT399F **[deeptrack.backend._config](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399F_backend._config.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399F_backend._config.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
-
-# Developer Tutorials
-
-Here you find a series of notebooks tailored for DeepTrack2's developers:
-
-- DTDV401 **[Overview of Code Base](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV401_overview.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV401_overview.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-- DTDV411 **[Style Guide](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV411_style.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV411_style.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
-
-# Documentation
-
-The detailed documentation of DeepTrack2 is available at the following link: [https://deeptrackai.github.io/DeepTrack2](https://deeptrackai.github.io/DeepTrack2)
-
-# Cite us!
-If you use DeepTrack 2.1 in your project, please cite us:
-
-<https://pubs.aip.org/aip/apr/article/8/1/011310/238663>
-```
+Benjamin Midtvedt, Saga Helgadottir, Aykut Argun, Jesús Pineda, Daniel Midtvedt, Giovanni Volpe.
 "Quantitative Digital Microscopy with Deep Learning."
-Benjamin Midtvedt, Saga Helgadottir, Aykut Argun, Jesús Pineda, Daniel Midtvedt & Giovanni Volpe.
-Applied Physics Reviews, volume 8, article number 011310 (2021).
+Applied Physics Reviews 8 (2021), 011310.
+https://doi.org/10.1063/5.0034891
 ```
 
 See also:
 
-<https://nostarch.com/deep-learning-crash-course>
+<https://www.nature.com/articles/s41467-022-35004-y>:
 ```
-Deep Learning Crash Course
-Benjamin Midtvedt, Jesús Pineda, Henrik Klein Moberg, Harshith Bachimanchi, Joana B. Pereira, Carlo Manzo & Giovanni Volpe.
-2025, No Starch Press (San Francisco, CA)
-ISBN-13: 9781718503922
-```
-
-
-<https://www.nature.com/articles/s41467-022-35004-y>
-```
+Midtvedt, B., Pineda, J., Skärberg, F. et al. 
 "Single-shot self-supervised object detection in microscopy." 
-Benjamin Midtvedt, Jesús Pineda, Fredrik Skärberg, Erik Olsén, Harshith Bachimanchi, Emelie Wesén, Elin K. Esbjörner, Erik Selander, Fredrik Höök, Daniel Midtvedt & Giovanni Volpe
-Nature Communications, volume 13, article number 7492 (2022).
+Nat Commun 13, 7492 (2022).
 ```
 
-<https://www.nature.com/articles/s42256-022-00595-0>
+<https://arxiv.org/abs/2202.06355>:
 ```
-"Geometric deep learning reveals the spatiotemporal fingerprint of microscopic motion."
-Jesús Pineda, Benjamin Midtvedt, Harshith Bachimanchi, Sergio Noé, Daniel Midtvedt, Giovanni Volpe & Carlo Manzo
-Nature Machine Intelligence volume 5, pages 71–82 (2023).
+Jesús Pineda, Benjamin Midtvedt, Harshith Bachimanchi, Sergio Noé, Daniel  Midtvedt, Giovanni Volpe,1 and  Carlo  Manzo
+"Geometric deep learning reveals the spatiotemporal fingerprint ofmicroscopic motion."
+arXiv 2202.06355 (2022).
 ```
 
-<https://doi.org/10.1364/OPTICA.6.000506>
+<https://doi.org/10.1364/OPTICA.6.000506>:
 ```
+Saga Helgadottir, Aykut Argun, and Giovanni Volpe.
 "Digital video microscopy enhanced by deep learning."
-Saga Helgadottir, Aykut Argun & Giovanni Volpe.
-Optica, volume 6, pages 506-513 (2019).
+Optica 6.4 (2019): 506-513.
 ```
 
-# Funding
+<https://github.com/softmatterlab/DeepTrack.git>:
+```
+Saga Helgadottir, Aykut Argun, and Giovanni Volpe.
+"DeepTrack." (2019)
+```
+
+## Funding
 
 This work was supported by the ERC Starting Grant ComplexSwimmers (Grant No. 677511), the ERC Starting Grant MAPEI (101001267), and the Knut and Alice Wallenberg Foundation.

--- a/README.md
+++ b/README.md
@@ -1,176 +1,312 @@
+<!-- GH_ONLY_START -->
 <p align="center">
-  <img width="350" src=https://github.com/softmatterlab/DeepTrack2/blob/develop/assets/logo.png?raw=true>
+  <img width="350" src=https://github.com/DeepTrackAI/DeepTrack2/blob/develop/assets/DeepTrack2-logo.png?raw=true>
 </p>
+<!-- GH_ONLY_END -->
 
-<h3 align="center">A comprehensive deep learning framework for digital microscopy.</h3>
+<h3 align="center">DeepTrack2 - A comprehensive deep learning framework for digital microscopy.</h3>
 <p align="center">
-  <a href="/LICENSE" alt="licence"><img src="https://img.shields.io/github/license/softmatterlab/DeepTrack-2.0"></a>
-  <a href="https://badge.fury.io/py/deeptrack"><img src="https://badge.fury.io/py/deeptrack.svg" alt="PyPI version"></a>
-  <a href="https://deeptrackai.github.io/DeepTrack2"><img src="https://img.shields.io/badge/docs-passing-green" alt="PyPI version"></a>
-  <a href="https://badge.fury.io/py/deeptrack"><img src="https://img.shields.io/badge/python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue" alt="Python version"></a>
-  <a href="https://doi.org/10.1063/5.0034891" alt="DOI">
-    <img src="https://img.shields.io/badge/DOI-10.1063%2F5.0034891-blue">
+  <a href="/LICENSE" alt="licence">
+    <img src="https://img.shields.io/github/license/DeepTrackAI/DeepTrack2">
+  </a>
+  <a href="https://badge.fury.io/py/deeptrack">
+    <img src="https://badge.fury.io/py/deeptrack.svg" alt="PyPI version">
+  </a>
+  <a href="https://deeptrackai.github.io/DeepTrack2">
+    <img src="https://img.shields.io/badge/docs-available-blue?logo=readthedocs">
+  </a>
+  <a href="https://badge.fury.io/py/deeptrack">
+    <img src="https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11%20%7C%203.12-blue" alt="Python version">
+  </a>
+  <a href="https://doi.org/10.1063/5.0034891">
+    <img src="https://img.shields.io/badge/cite us-10.1063%2F5.0034891-blue">
   </a>
 </p>
 <p align="center">
   <a href="#installation">Installation</a> •
-  <a href="#examples-of-applications-using-deeptrack">Examples</a> •
-  <a href="#getting-started-guides">Basics</a> •
+  <a href="#getting-started">Getting Started</a> •
+  <a href="#examples">Examples</a> •
+  <a href="#advanced-tutorials">Advanced Tutorials</a> •
+  <a href="#developer-tutorials">Developer Tutorials</a> •
   <a href="#cite-us">Cite us</a> •
   <a href="/LICENSE">License</a> 
 </p>
 
+DeepTrack2 is a modular Python library for generating, manipulating, and analyzing image data pipelines for machine learning and experimental imaging.
 
-We provide tools to create physical simulations of optical systems, to generate and train neural network models, and to analyze experimental data.
+<b>TensorFlow Compatibility Notice:</b> 
+DeepTrack2 version 2.0 and subsequent do not support TensorFlow. If you need TensorFlow support, please install the legacy version 1.7.
+
+The following quick start guide is intended for complete beginners to understand how to use DeepTrack2, from installation to training your first model. Let's get started!
 
 # Installation
 
-DeepTrack 2.1 requires at least python 3.6.
+DeepTrack2 2.0 requires at least python 3.9.
 
-To install DeepTrack 2.1, open a terminal or command prompt and run:
-
-    pip install deeptrack
-    
-If you have a very recent version of python, you may need to install numpy _before_ DeepTrack. This is a known issue with scikit-image.
-
-### Updating to 2.1 from 2.0
-
-If you are already using DeepTrack 2.0 (pypi version 0.x.x), updating to DeepTrack 2.1 (pypi version 1.x.x) is painless. If you have followed deprecation warnings, no change to your code is needed. There are two breaking changes:
-
-- The deprecated operator `+` to chain features has been removed. It is now only possible using the `>>` operator.
-- The deprecated operator `**` to duplicate a feature has been removed. It is now only possible using the `^` operator.
-
-If you notice any other changes in behavior, please report it to us in the issues tab.
-
-# Examples of applications using DeepTrack 
-
-DeepTrack is a general purpose deep learning framework for microscopy, meaning you can use it for any task you like. Here, we show some common applications!
-
-<br/>
-<h3 align="left"> Single particle tracking </h3>
-<p align="left">
-  <img width="300" src=/assets/SPT-ideal.gif?raw=true>
-  <img width="300" src=/assets/SPT-noisy.gif?raw=true>
-  <br/>
-  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/paper-examples/2-single_particle_tracking.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training a CNN-based single particle tracker using simulated data </a>
-  <br/>
-  <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="DOI lodestar">
-    <img src="https://img.shields.io/badge/DOI-10.1038%2Fs41467--022--35004--y-blue">
-  </a> 
-  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/LodeSTAR/02.%20tracking_particles_of_various_shapes.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Unsupervised training of a single particle tracker using LodeSTAR </a> 
-  
-</p>
-<br/>
-
-<h3 align="left"> Multi-particle tracking </h3>
-
-<p align="left">
-  <img width="600" src=/assets/MPT-packed.gif?raw=true>
-  <br/>
-  <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="DOI lodestar">
-    <img src="https://img.shields.io/badge/DOI-10.1038%2Fs41467--022--35004--y-blue">
-  </a> <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/LodeSTAR/03.track_BF-C2DL-HSC.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training LodeSTAR to detect multiple cells from a single image </a>
-  <br/>
-  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/paper-examples/4-multi-molecule-tracking.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Training a UNet-based multi-particle tracker using simulated data </a> 
-</p>
-<br/>
-
-<h3 align="left"> Particle tracing </h3>
-
-<p align="left">
-  <img width="600" src=/assets/Tracing.gif?raw=true>
-  <br/>
-  <a href="https://doi.org/10.48550/arXiv.2202.06355" alt="DOI magik">
-    <img src="https://img.shields.io/badge/DOI-10.48550%2FarXiv.2202.0635-blue">
-  </a>  <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/develop/examples/MAGIK/cell_migration_analysis.ipynb"> <img     src="https://colab.research.google.com/assets/colab-badge.svg"> Training MAGIK to trace migrating cells </a>
-</p>
-
-# Basics to learn DeepTrack 2.1
-
-Everybody learns in different ways! Depending on your preferences, and what you want to do with DeepTrack, you may want to check out one or more of these resources.
-
-## Getting-started guides
-
-We have two separate series of notebooks which aims to teach you all you need to know to use DeepTrack to its fullest. The first is a set of six notebooks with a focus on the application.
-
-1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> deeptrack_introduction_tutorial </a>  gives an overview of how to use DeepTrack 2.1.
-2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/tutorials/tracking_particle_cnn_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_cnn_tutorial </a> demonstrates how to track a point particle with a convolutional neural network (CNN).
-3. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/tutorials/tracking_multiple_particles_unet_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> tracking_particle_unet_tutorial </a> demonstrates how to track multiple particles using a U-net.
-4. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/tutorials/characterizing_aberrations_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> characterizing_aberrations_tutorial </a> demonstrates how to add and characterize aberrations of an optical device. 
-5. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/tutorials/distinguishing_particles_in_brightfield_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> distinguishing_particles_in_brightfield_tutorial </a> demonstrates how to use a U-net to track and distinguish particles of different sizes in brightfield microscopy. 
-6. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/tutorials/analyzing_video_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> analyzing_video_tutorial </a> demonstrates how to create videos and how to train a neural network to analyze them.
-
-
-The second series focuses on individual topics, introducing them in a natural order. 
-
-1. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/get-started/01.%20deeptrack_introduction_tutorial.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Introducing how to create simulation pipelines and train models. </a>
-2. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/get-started/02.%20using_deeptrack_generators.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Demonstrating data generators. </a> 
-3. <a href="https://colab.research.google.com/github/softmatterlab/DeepTrack-2.0/blob/master/examples/get-started/03.%20customizing_deeptrack_models.ipynb"> <img src="https://colab.research.google.com/assets/colab-badge.svg"> Demonstrating how to customize models using layer-blocks. </a> 
-
-## DeepTrack 2.1 in action
-
-Additionally, we have seven more case studies which are less documented, but gives additional insight in how to use DeepTrack with real datasets
-
-1. [MNIST](examples/paper-examples/1-MNIST.ipynb) classifies handwritted digits.
-2. [single particle tracking](examples/paper-examples/2-single_particle_tracking.ipynb) tracks experimentally captured videos of a single particle. (Requires opencv-python compiled with ffmpeg to open and read a video.)
-3. [single particle sizing](examples/paper-examples/3-particle_sizing.ipynb) extracts the radius and refractive index of particles.
-4. [multi-particle tracking](examples/paper-examples/4-multi-molecule-tracking.ipynb) detects quantum dots in a low SNR image.
-5. [3-dimensional tracking](examples/paper-examples/5-inline_holography_3d_tracking.ipynb) tracks particles in three dimensions.
-6. [cell counting](examples/paper-examples/6-cell_counting.ipynb) counts the number of cells in fluorescence images.
-7. [GAN image generation](examples/paper-examples/7-GAN_image_generation.ipynb) uses a GAN to create cell image from masks.
-
-## Model-specific examples
-
-We also have examples that are specific for certain models. This includes 
-- [*LodeSTAR*](examples/LodeSTAR) for label-free particle tracking.
-- [*MAGIK*](examples/MAGIK) for graph-based particle linking and trace characterization.
-
-## Documentation
-The detailed documentation of DeepTrack 2.1 is available at the following link: https://deeptrackai.github.io/DeepTrack2
-
-## Video Tutorials
-
-Videos are currently being updated to match with the current version of DeepTrack.
-
-## Cite us!
-If you use DeepTrack 2.1 in your project, please cite us here:
-
+To install DeepTrack2, open a terminal or command prompt and run:
+```bash
+pip install deeptrack
 ```
-Benjamin Midtvedt, Saga Helgadottir, Aykut Argun, Jesús Pineda, Daniel Midtvedt, Giovanni Volpe.
+or
+```bash
+python -m pip install deeptrack
+```
+This will automatically install the required dependencies.
+
+# Getting Started
+
+Here you find a series of notebooks that give you an overview of the core features of DeepTrack2 and how to use them:
+
+- DTGS101 **[Introduction to DeepTrack2](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS101_intro.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS101_intro.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Overview of how to use DeepTrack 2. Creating images combining DeepTrack2 features, extracting properties, and using them to train a neural network.
+
+- DTGS111 **[Loading Image Files Using Sources](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS111_datafiles.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS111_datafiles.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Using sources to load image files and to train a neural network.
+
+- DTGS121 **[Tracking a Point Particle with a CNN](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS121_tracking_particle_cnn.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS121_tracking_particle_cnn.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Tracking a point particle with a convolutional neural network (CNN) using simulated images in the training process.
+
+- DTGS131 **[Tracking Multiple Particles with a U-Net](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS131_tracking_multiple_particles_unet.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS131_tracking_multiple_particles_unet.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Tracking multiple particles using a U-net trained on simulated images.
+
+- DTGS141 **[Distinguishing Particles with a U-Net](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS141_distinguishing_particles_in_brightfield.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS141_distinguishing_particles_in_brightfield.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Tracking and distinguishing particles of different sizes in brightfield microscopy using a U-net trained on simulated images.
+
+- DTGS151 **[Unsupervised Object Detection](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS151_unsupervised_object_detection_with_lodestar.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS151_unsupervised_object_detection_with_lodestar.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Single-shot unsupervised object detection a using LodeSTAR.
+
+# Examples
+
+These are examples of how DeepTrack2 can be used on real datasets:
+
+- DTEx211 **[MNIST](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx201_MNIST.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx201_MNIST.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+  Training a fully connected neural network to identify handwritten digits using MNIST dataset.
+
+- DTEx212 **Single Particle Tracking**
+
+  Tracks experimental videos of a single particle. (Requires opencv-python compiled with ffmpeg)
+
+  <!-- GH_ONLY_START -->
+  <p align="left">
+    <img width="300" src=/assets/SPT-ideal.gif?raw=true>
+    <img width="300" src=/assets/SPT-noisy.gif?raw=true>
+    <br/>
+    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx202_single_particle_tracking.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg">
+    </a>
+    <a href="https://doi.org/10.1364/OPTICA.6.000506" alt="DeepTrack article">
+      <img src="https://img.shields.io/badge/article-10.1364/OPTICA.6.000506-blue">
+    </a> 
+    <br/>
+    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx231B_LodeSTAR_tracking_particles_of_various_shapes.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg">
+    </a>
+    <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="LodeSTAR article">
+      <img src="https://img.shields.io/badge/article-10.1038%2Fs41467--022--35004--y-blue">
+    </a> 
+  </p>
+  <!-- GH_ONLY_END -->
+
+- DTEx213 **Multi-Particle tracking**
+- 
+  Detecting quantum dots in a low SNR image.
+
+  <!-- GH_ONLY_START -->
+  <p align="left">
+    <img width="600" src=/assets/MPT-packed.gif?raw=true>
+    <br/>
+    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx203_particle_sizing.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg">
+    </a>
+    <a href="https://doi.org/10.1063/5.0034891" alt="LodeSTAR article">
+      <img src="https://img.shields.io/badge/article-10.1063/5.0034891-blue">
+    </a> 
+    <br/>
+    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx231A_LodeSTAR_autotracker_template.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg">
+    </a>
+    <a href="https://doi.org/10.1038/s41467-022-35004-y" alt="Article LodeSTAR">
+      <img src="https://img.shields.io/badge/article-10.1038%2Fs41467--022--35004--y-blue">
+    </a>
+  </p>
+  <!-- GH_ONLY_END -->
+
+- DTEx214 **Particle Feature Extraction**
+- 
+  Extracting the radius and refractive index of particles.
+
+- DTEx215 **Cell Counting**
+
+  Counting the number of cells in fluorescence images.
+
+- DTEx216 **3D Multi-Particle tracking**
+
+  Tracking multiple particles in 3D for holography.
+
+- DTEx217 **GAN image generation**
+
+  Using a GAN to create cell image from masks.
+
+Specific examples for label-free particle tracking using **LodeSTAR**:
+
+- DTEx231A **LodeSTAR Autotracker Template**
+
+- DTEx231B **LodeSTAR Detecting Particles of Various Shapes**
+
+- DTEx231C **LodeSTAR Measuring the Mass of Particles in Holography**
+
+- DTEx231D **LodeSTAR Detecting the Cells in the BF-C2DT-HSC Dataset**
+
+- DTEx231E **LodeSTAR Detecting the Cells in the Fluo-C2DT-Huh7 Dataset**
+  
+- DTEx231F **LodeSTAR Detecting the Cells in the PhC-C2DT-PSC Dataset**
+  
+- DTEx231G **LodeSTAR Detecting Plankton**
+  
+- DTEx231H **LodeSTAR Detecting in 3D Holography**
+
+- DTEx231I **LodeSTAR Measuring the Mass of Simulated Particles**
+  
+- DTEx231J **LodeSTAR Measuring the Mass of Cells**
+
+Specific examples for graph-neural-network-based particle linking and trace characterization using **MAGIK**:
+
+- DTEx241A **MAGIK Tracing Migrating Cells**
+
+  <!-- GH_ONLY_START -->
+  <p align="left">
+    <img width="600" src=/assets/Tracing.gif?raw=true>
+    <br/>
+    <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/2-examples/DTEx241A_MAGIK_cell_migration_analysis.ipynb">
+      <img src="https://colab.research.google.com/assets/colab-badge.svg">
+    </a>
+    <a href="https://doi.org/10.1038/s42256-022-00595-0" alt="Article MAGIK">
+      <img src="https://img.shields.io/badge/article-10.1038/s42256--022--00595--0-blue">
+    </a>  
+  </p>
+  <!-- GH_ONLY_END -->
+
+- DTEx241B **MAGIK to Track HeLa Cells**
+
+# Advanced Tutorials
+
+This section provides a list of advanced topic tutorials. The primary focus of these tutorials is to demonstrate the functionalities of individual modules and how they work in relative isolation, helping to provide a better understanding of them and their roles in DeepTrack2.
+
+- DTAT301 **[deeptrack.features](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT301_features.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT301_features.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT306 **[deeptrack.properties](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT306_properties.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT306_properties.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT311 **[deeptrack.image](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT311_image.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT311_image.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT321 **[deeptrack.scatterers](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT321_scatterers.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT321_scatterers.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT323 **[deeptrack.optics](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT323_optics.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT323_optics.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT324 **[deeptrack.holography](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT324_holography.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT324_holography.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT325 **[deeptrack.aberrations](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT325_aberrations.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT325_aberrations.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT327 **[deeptrack.noises](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT327_noises.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT327_noises.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT329 **[deeptrack.augmentations](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT329_augmentations.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT329_augmentations.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT341 **[deeptrack.sequences](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT341_sequences.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT341_sequences.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT381 **[deeptrack.math](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT381_math.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT381_math.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT383 **[deeptrack.utils](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT383_utils.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT383_utils.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTAT385 **[deeptrack.statistics](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT385_statistics.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT385_statistics.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT387 **[deeptrack.types](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT389 **[deeptrack.elementwise](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT389_elementwise.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT389_elementwise.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT391A **[deeptrack.sources.base](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391A_sources.base.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391A_sources.base.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT391B **[deeptrack.sources.folder](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391B_sources.folder.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391B_sources.folder.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT391C **[deeptrack.sources.rng](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391C_sources.rng.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT391C_sources.rng.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT393A **[deeptrack.pytorch.data](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393A_pytorch.features.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393A_pytorch.features.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT393B **[deeptrack.pytorch.features](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393B_pytorch.data.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT393B_pytorch.data.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT395 **[deeptrack.extras.radialcenter](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT395_extras.radialcenter.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT395_extras.radialcenter.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+- DTAT399A **[deeptrack.backend.core](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399A_backend.core.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399A_backend.core.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+  
+- DTAT399B **[deeptrack.backend.pint_definition](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399B_backend.pint_definition.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399B_backend.pint_definition.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+  
+- DTAT399C **[deeptrack.backend.units](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399C_backend.units.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399C_backend.units.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+  
+- DTAT399D **[deeptrack.backend.polynomials](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399D_backend.polynomials.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399D_backend.polynomials.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+  
+- DTAT399E **[deeptrack.backend.mie](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399E_backend.mie.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399E_backend.mie.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+  
+- DTAT399F **[deeptrack.backend._config](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399F_backend._config.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT399F_backend._config.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+
+# Developer Tutorials
+
+Here you find a series of notebooks tailored for DeepTrack2's developers:
+
+- DTDV401 **[Overview of Code Base](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV401_overview.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV401_overview.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+- DTDV411 **[Style Guide](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV411_style.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/4-developers/DTDV411_style.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+
+# Documentation
+
+The detailed documentation of DeepTrack2 is available at the following link: [https://deeptrackai.github.io/DeepTrack2](https://deeptrackai.github.io/DeepTrack2)
+
+# Cite us!
+If you use DeepTrack 2.1 in your project, please cite us:
+
+<https://pubs.aip.org/aip/apr/article/8/1/011310/238663>
+```
 "Quantitative Digital Microscopy with Deep Learning."
-Applied Physics Reviews 8 (2021), 011310.
-https://doi.org/10.1063/5.0034891
+Benjamin Midtvedt, Saga Helgadottir, Aykut Argun, Jesús Pineda, Daniel Midtvedt & Giovanni Volpe.
+Applied Physics Reviews, volume 8, article number 011310 (2021).
 ```
 
 See also:
 
-<https://www.nature.com/articles/s41467-022-35004-y>:
+<https://nostarch.com/deep-learning-crash-course>
 ```
-Midtvedt, B., Pineda, J., Skärberg, F. et al. 
+Deep Learning Crash Course
+Benjamin Midtvedt, Jesús Pineda, Henrik Klein Moberg, Harshith Bachimanchi, Joana B. Pereira, Carlo Manzo & Giovanni Volpe.
+2025, No Starch Press (San Francisco, CA)
+ISBN-13: 9781718503922
+```
+
+
+<https://www.nature.com/articles/s41467-022-35004-y>
+```
 "Single-shot self-supervised object detection in microscopy." 
-Nat Commun 13, 7492 (2022).
+Benjamin Midtvedt, Jesús Pineda, Fredrik Skärberg, Erik Olsén, Harshith Bachimanchi, Emelie Wesén, Elin K. Esbjörner, Erik Selander, Fredrik Höök, Daniel Midtvedt & Giovanni Volpe
+Nature Communications, volume 13, article number 7492 (2022).
 ```
 
-<https://arxiv.org/abs/2202.06355>:
+<https://www.nature.com/articles/s42256-022-00595-0>
 ```
-Jesús Pineda, Benjamin Midtvedt, Harshith Bachimanchi, Sergio Noé, Daniel  Midtvedt, Giovanni Volpe,1 and  Carlo  Manzo
-"Geometric deep learning reveals the spatiotemporal fingerprint ofmicroscopic motion."
-arXiv 2202.06355 (2022).
+"Geometric deep learning reveals the spatiotemporal fingerprint of microscopic motion."
+Jesús Pineda, Benjamin Midtvedt, Harshith Bachimanchi, Sergio Noé, Daniel Midtvedt, Giovanni Volpe & Carlo Manzo
+Nature Machine Intelligence volume 5, pages 71–82 (2023).
 ```
 
-<https://doi.org/10.1364/OPTICA.6.000506>:
+<https://doi.org/10.1364/OPTICA.6.000506>
 ```
-Saga Helgadottir, Aykut Argun, and Giovanni Volpe.
 "Digital video microscopy enhanced by deep learning."
-Optica 6.4 (2019): 506-513.
+Saga Helgadottir, Aykut Argun & Giovanni Volpe.
+Optica, volume 6, pages 506-513 (2019).
 ```
 
-<https://github.com/softmatterlab/DeepTrack.git>:
-```
-Saga Helgadottir, Aykut Argun, and Giovanni Volpe.
-"DeepTrack." (2019)
-```
-
-## Funding
+# Funding
 
 This work was supported by the ERC Starting Grant ComplexSwimmers (Grant No. 677511), the ERC Starting Grant MAPEI (101001267), and the Knut and Alice Wallenberg Foundation.


### PR DESCRIPTION
* Edited readme to have working colab links and removed links which do not point to existing notebooks.
* DeepTrack logo now points to the image in the 1.7 branch.