### PR TITLE
Sequences Restructuring 

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -139,7 +139,7 @@ from deeptrack.backend import config
 from deeptrack.backend.core import DeepTrackNode
 from deeptrack.backend.units import ConversionTable, create_context
 from deeptrack.image import Image
-from deeptrack.properties import PropertyDict
+from deeptrack.properties import PropertyDict, SequentialProperty
 from deeptrack.sources import SourceItem
 from deeptrack.types import ArrayLike, PropertyLike
 
@@ -493,6 +493,70 @@ class Feature(DeepTrackNode):
 
     resolve = __call__
 
+    def to_sequential(
+            feature: Feature,
+            **kwargs
+    ) -> Feature:
+        
+        """Converts a feature to be resolved as a sequence.
+
+        Should be called on individual features, not combinations of features. All
+        keyword arguments will be trated as sequential properties and will be
+        passed to the parent feature.
+
+        If a property from the keyword argument already exists on the feature, the
+        existing property will be used to initilize the passed property (that is,
+        it will be used for the first timestep).
+
+        Parameters
+        ----------
+        feature : Feature
+            Feature to make sequential.
+        kwargs
+            Keyword arguments to pass on as sequential properties of `feature`.
+
+        """
+
+        for property_name in kwargs.keys():
+
+            if property_name in feature.properties:
+                # Insert property with initialized value
+                feature.properties[property_name] = SequentialProperty(
+                    feature.properties[property_name], **feature.properties
+                )
+            else:
+                # insert empty property
+                feature.properties[property_name] = SequentialProperty()
+
+            feature.properties.add_dependency(feature.properties[property_name])
+            feature.properties[property_name].add_child(feature.properties)
+
+        for property_name, sampling_rule in kwargs.items():
+
+            prop = feature.properties[property_name]
+
+            all_kwargs = dict(
+                previous_value=prop.previous_value,
+                previous_values=prop.previous_values,
+                sequence_length=prop.sequence_length,
+                sequence_step=prop.sequence_step,
+            )
+
+            for key, val in feature.properties.items():
+                if key == property_name:
+                    continue
+
+                if isinstance(val, SequentialProperty):
+                    all_kwargs[key] = val
+                    all_kwargs["previous_" + key] = val.previous_values
+                else:
+                    all_kwargs[key] = val
+            if not prop.initialization:
+                prop.initialization = prop.create_action(sampling_rule, **{k:all_kwargs[k] for k in all_kwargs if k != "previous_value"})
+
+            prop.current = prop.create_action(sampling_rule, **all_kwargs)
+
+        return feature
 
     def store_properties(
         self: Feature,


### PR DESCRIPTION
WIP of restructuring sequences to be more intuitive.

* `to_sequential()` is a `Feature` method intended to replace `Sequential` found in `sequences.py`.

`Sequential()`  is a method is used as:
```
rotating_ellipse = deeptrack.sequences.Sequential(rotation=get_rotation)
imaged_rotating_ellipse = optics(rotating_ellipse)
...
```
The new `Feature` method `to_sequential()` replaces this, and is used as:
```
rotating_ellipse = ellipse.to_sequential(rotation=get_rotation)
imaged_rotating_ellipse = optics(rotating_ellipse)
...
```