### PR TITLE
Sequences restructuring

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -139,7 +139,7 @@ from deeptrack.backend import config
 from deeptrack.backend.core import DeepTrackNode
 from deeptrack.backend.units import ConversionTable, create_context
 from deeptrack.image import Image
-from deeptrack.properties import PropertyDict
+from deeptrack.properties import PropertyDict, SequentialProperty
 from deeptrack.sources import SourceItem
 from deeptrack.types import ArrayLike, PropertyLike
 
@@ -493,6 +493,70 @@ class Feature(DeepTrackNode):
 
     resolve = __call__
 
+    def to_sequential(
+            feature: Feature,
+            **kwargs
+    ) -> Feature:
+        
+        """Converts a feature to be resolved as a sequence.
+
+        Should be called on individual features, not combinations of features. All
+        keyword arguments will be trated as sequential properties and will be
+        passed to the parent feature.
+
+        If a property from the keyword argument already exists on the feature, the
+        existing property will be used to initilize the passed property (that is,
+        it will be used for the first timestep).
+
+        Parameters
+        ----------
+        feature : Feature
+            Feature to make sequential.
+        kwargs
+            Keyword arguments to pass on as sequential properties of `feature`.
+
+        """
+
+        for property_name in kwargs.keys():
+
+            if property_name in feature.properties:
+                # Insert property with initialized value
+                feature.properties[property_name] = SequentialProperty(
+                    feature.properties[property_name], **feature.properties
+                )
+            else:
+                # insert empty property
+                feature.properties[property_name] = SequentialProperty()
+
+            feature.properties.add_dependency(feature.properties[property_name])
+            feature.properties[property_name].add_child(feature.properties)
+
+        for property_name, sampling_rule in kwargs.items():
+
+            prop = feature.properties[property_name]
+
+            all_kwargs = dict(
+                previous_value=prop.previous_value,
+                previous_values=prop.previous_values,
+                sequence_length=prop.sequence_length,
+                sequence_step=prop.sequence_step,
+            )
+
+            for key, val in feature.properties.items():
+                if key == property_name:
+                    continue
+
+                if isinstance(val, SequentialProperty):
+                    all_kwargs[key] = val
+                    all_kwargs["previous_" + key] = val.previous_values
+                else:
+                    all_kwargs[key] = val
+            if not prop.initialization:
+                prop.initialization = prop.create_action(sampling_rule, **{k:all_kwargs[k] for k in all_kwargs if k != "previous_value"})
+
+            prop.current = prop.create_action(sampling_rule, **all_kwargs)
+
+        return feature
 
     def store_properties(
         self: Feature,

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -494,7 +494,7 @@ class Feature(DeepTrackNode):
     resolve = __call__
 
     def to_sequential(
-            feature: Feature,
+            self: Feature,
             **kwargs
     ) -> Feature:
         """Converts a feature to be resolved as a sequence.

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -497,24 +497,28 @@ class Feature(DeepTrackNode):
             feature: Feature,
             **kwargs
     ) -> Feature:
-        
         """Converts a feature to be resolved as a sequence.
 
         Should be called on individual features, not combinations of features. All
-        keyword arguments will be trated as sequential properties and will be
+        keyword arguments will be treated as sequential properties and will be
         passed to the parent feature.
 
         If a property from the keyword argument already exists on the feature, the
-        existing property will be used to initilize the passed property (that is,
+        existing property will be used to initialize the passed property (that is,
         it will be used for the first timestep).
 
         Parameters
         ----------
-        feature : Feature
+        feature: Feature
             Feature to make sequential.
         kwargs
             Keyword arguments to pass on as sequential properties of `feature`.
-
+            
+        Returns
+        -------
+        Feature
+            The input feature evolved as a sequence
+            
         """
 
         for property_name in kwargs.keys():

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -509,7 +509,7 @@ class Feature(DeepTrackNode):
 
         Parameters
         ----------
-        feature: Feature
+        self: Feature
             Feature to make sequential.
         kwargs
             Keyword arguments to pass on as sequential properties of `feature`.
@@ -523,21 +523,21 @@ class Feature(DeepTrackNode):
 
         for property_name in kwargs.keys():
 
-            if property_name in feature.properties:
+            if property_name in self.properties:
                 # Insert property with initialized value
-                feature.properties[property_name] = SequentialProperty(
-                    feature.properties[property_name], **feature.properties
+                self.properties[property_name] = SequentialProperty(
+                    self.properties[property_name], **self.properties
                 )
             else:
                 # insert empty property
-                feature.properties[property_name] = SequentialProperty()
+                self.properties[property_name] = SequentialProperty()
 
-            feature.properties.add_dependency(feature.properties[property_name])
-            feature.properties[property_name].add_child(feature.properties)
+            self.properties.add_dependency(self.properties[property_name])
+            self.properties[property_name].add_child(self.properties)
 
         for property_name, sampling_rule in kwargs.items():
 
-            prop = feature.properties[property_name]
+            prop = self.properties[property_name]
 
             all_kwargs = dict(
                 previous_value=prop.previous_value,
@@ -546,7 +546,7 @@ class Feature(DeepTrackNode):
                 sequence_step=prop.sequence_step,
             )
 
-            for key, val in feature.properties.items():
+            for key, val in self.properties.items():
                 if key == property_name:
                     continue
 
@@ -560,7 +560,7 @@ class Feature(DeepTrackNode):
 
             prop.current = prop.create_action(sampling_rule, **all_kwargs)
 
-        return feature
+        return self
 
     def store_properties(
         self: Feature,

--- a/deeptrack/properties.py
+++ b/deeptrack/properties.py
@@ -530,6 +530,7 @@ class SequentialProperty(Property):
     def __init__(
         self,
         initialization: Optional[Any] = None,
+        current_value: optional[Any] = None,
         **kwargs: Dict[str, 'Property'],
     ):
         """Create a SequentialProperty with optional initialization.
@@ -586,7 +587,10 @@ class SequentialProperty(Property):
             self.initialization = None
 
         # 6) Define a default current function for steps >= 1.
-        self.current = lambda _ID=(): None
+        if current_value is not None:
+            self.current = self.create_action(current_value,**kwargs)
+        else:
+            self.current = lambda _ID=(): None
 
         # 7) Override the default action with our custom logic.
         self.action = self._action_override
@@ -682,3 +686,25 @@ class SequentialProperty(Property):
         """
 
         return super().__call__(_ID=_ID)
+        
+    def set_sequence_length(
+        self,
+        value: Any,
+        _ID: Tuple[int, ...] = ()
+    ) -> None:
+        """Sets the length of sequence to be resolved.
+        ...
+        
+        """
+        self.sequence_length = Property(value, _ID=_ID)
+
+
+    def set_current_step(
+            self,
+            value:Any,
+            _ID: Tuple[int, ...] = ()
+    ) -> None:
+        """Sets the current index of the sequence.
+    
+        """
+        self.sequence_step = Property(value, _ID=_ID)

--- a/deeptrack/properties.py
+++ b/deeptrack/properties.py
@@ -81,7 +81,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 from .utils import get_kwarg_names
-from .backend.core import DeepTrackNode
+from deeptrack.backend.core import DeepTrackNode
 
 
 class Property(DeepTrackNode):
@@ -588,7 +588,7 @@ class SequentialProperty(Property):
 
         # 6) Define a default current function for steps >= 1.
         if current_value is not None:
-            self.current = self.create_action(current_value,**kwargs)
+            self.current = self.create_action(current_value, **kwargs)
         else:
             self.current = lambda _ID=(): None
 
@@ -692,19 +692,48 @@ class SequentialProperty(Property):
         value: Any,
         _ID: Tuple[int, ...] = ()
     ) -> None:
-        """Sets the length of sequence to be resolved.
-        ...
-        
-        """
-        self.sequence_length = Property(value, _ID=_ID)
+        """Sets the `sequence_length` attribute of a sequence to be resolved.
 
+        Supports dependencies if `value` is a `Property`.
+
+        Parameters
+        ----------
+        value : Any
+            The value to store in `sequence_length`.
+        _ID : Tuple[int, ...], optional
+            A unique identifier that allows the property to keep separate 
+            histories for different parallel evaluations.
+
+        """
+
+        if isinstance(value, Property):
+            self.sequence_length = Property(lambda _ID: value(_ID))
+            self.sequence_length.add_dependency(value)
+        else: 
+            self.sequence_length = Property(value, _ID=_ID)
 
     def set_current_step(
-            self,
-            value:Any,
-            _ID: Tuple[int, ...] = ()
+        self,
+        value: Any,
+        _ID: Tuple[int, ...] = ()
     ) -> None:
-        """Sets the current index of the sequence.
+        """Sets the `current_index` attribute of a sequence to be resolved.
+
+        Supports dependencies if `value` is a `Property`.
+
+        Parameters
+        ----------
+        value : Any
+            The value to store in `current_step`.
+
+        _ID : Tuple[int, ...], optional
+            A unique identifier that allows the property to keep separate 
+            histories for different parallel evaluations.
     
         """
-        self.sequence_step = Property(value, _ID=_ID)
+
+        if isinstance(value, Property): # For dependencies.
+            self.sequence_step = Property(lambda _ID: value(_ID))
+            self.sequence_step.add_dependency(value)
+        else:
+            self.sequence_step = Property(value, _ID=_ID)

--- a/deeptrack/properties.py
+++ b/deeptrack/properties.py
@@ -530,7 +530,7 @@ class SequentialProperty(Property):
     def __init__(
         self,
         initialization: Optional[Any] = None,
-        current_value: optional[Any] = None,
+        current_value: Optional[Any] = None,
         **kwargs: Dict[str, 'Property'],
     ):
         """Create a SequentialProperty with optional initialization.

--- a/deeptrack/sequences.py
+++ b/deeptrack/sequences.py
@@ -69,7 +69,7 @@ class Sequence(Feature):
         return outputs
 
 
-def Sequential(feature: Feature, **kwargs):
+def Sequential(feature: Feature, **kwargs): #TBE, Replaced by Feature.to_sequential()
     """Converts a feature to be resolved as a sequence.
 
     Should be called on individual features, not combinations of features. All


### PR DESCRIPTION
WIP of restructuring `sequences.py` and `SequentialProperty`.

##  Changes to `SequentialProperty`:
* `SequentialProperty` now has two new methods:

`set_sequence_length()`, `set_sequence_step()`, which lets you directly set the Property.sequence_length and Property.sequence_step attributes without having to use `SequentialProperty.store()`.

* `SequentialProperty` now has one new optional argument:

`current_value`, which is assigned to the `SequentialProperty.current` attribute upon calling `__init__()`.


## Changes to `Feature`:
`to_sequential()` is a new `Feature` class method intended to replace the `Sequential()` method found in `sequences.py`.

`Sequential()` is used as:
```
rotating_ellipse = deeptrack.sequences.Sequential(rotation=get_rotation)
imaged_rotating_ellipse = optics(rotating_ellipse)
```
The new `Feature` method `to_sequential()` is used as:
```
rotating_ellipse = ellipse.to_sequential(rotation=get_rotation)
imaged_rotating_ellipse = optics(rotating_ellipse)
```

