### PR TITLE
Remove features from Store properties

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -6011,7 +6011,7 @@ class Store(Feature):
 
         """
 
-        super().__init__(feature=feature, key=key, replace=replace, **kwargs)
+        super().__init__(key=key, replace=replace, **kwargs)
         self.feature = self.add_feature(feature, **kwargs)
         self._store: dict[Any, Image] = {}
 


### PR DESCRIPTION
Fixes an issue where `feature` was both set as a property of the Store class, as well as a attribute. With this PR, it is only an attribute. 

This caused feature to be recalculated unecessarily, bypassing the memoization of the Store.

This change causes no changes in output (so no breaking change), but should significantly speed up pipelines using Store. 