### PR TITLE
Bm/implement-device-dtype

### DIFF
--- a/deeptrack/backend/_config.py
+++ b/deeptrack/backend/_config.py
@@ -101,9 +101,7 @@ class _Proxy(types.ModuleType):
             Name of the proxy object. This is used when printing the object.
 
         """
-
-        self._backend = apcnumpy
-        self._backend_info = apcnumpy.__array_namespace_info__.dtypes()
+        self.set_backend(apcnumpy)
         self.__name__ = name
 
     def set_backend(self: _Proxy, backend: types.ModuleType) -> None:
@@ -117,7 +115,7 @@ class _Proxy(types.ModuleType):
         """
 
         self._backend = backend
-        self._backend_info = backend.__array_namespace_info__.dtypes()
+        self._backend_info = backend.__array_namespace_info__()
 
     def get_float_dtype(self: _Proxy, dtype: str) -> str:
         """Get the float dtype.

--- a/deeptrack/backend/_config.py
+++ b/deeptrack/backend/_config.py
@@ -69,7 +69,7 @@ class _Proxy(types.ModuleType):
     """Keep track of current backend and forward calls to the correct backend.
 
     An instance of this object will be treated as the module `xp`. It acts like
-    a shallow wrapper around the actual backend (for example `numpy` or 
+    a shallow wrapper around the actual backend (for example `numpy` or
     `torch`), and forwards calls to the correct backend.
 
     This is especially useful for array creation functions, to ensure that the
@@ -103,7 +103,69 @@ class _Proxy(types.ModuleType):
         """
 
         self._backend = apcnumpy
+        self._backend_info = apcnumpy.__array_namespace_info__.dtypes()
         self.__name__ = name
+
+    def set_backend(self: _Proxy, backend: types.ModuleType) -> None:
+        """Set the backend to use.
+
+        Parameters
+        ----------
+        backend: types.ModuleType
+            The backend to use.
+
+        """
+
+        self._backend = backend
+        self._backend_info = backend.__array_namespace_info__.dtypes()
+
+    def get_float_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the float dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["real floating"]
+        else:
+            return self._backend_info.dtypes("real floating")[dtype]
+
+    def get_int_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the int dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["integer"]
+        else:
+            return self._backend_info.dtypes("integer")[dtype]
+
+    def get_complex_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the complex dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["complex floating"]
+        else:
+            return self._backend_info.dtypes("complex floating")[dtype]
+
+    def get_bool_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the bool dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["bool"]
+        else:
+            return self._backend_info.dtypes("bool")[dtype]
 
     def __getattr__(self: _Proxy, attribute: str) -> Any:
         """Forward attribute access to the current backend.
@@ -209,7 +271,7 @@ class Config:
         Can be a string, most typically "cpu", "gpu", "cuda", "mps", or
         torch.device. In any case, it needs to be used with a compatible
         backend.
-        
+
         It can only be "cpu" when using NumPy backend.
 
         Parameters
@@ -263,7 +325,7 @@ class Config:
             from deeptrack.backend import array_api_compat_ext
 
         self.backend = backend
-        xp._backend = importlib.import_module(f"array_api_compat.{backend}")
+        xp.set_backend(importlib.import_module(f"array_api_compat.{backend}"))
 
     def get_backend(self: Config) -> Literal["numpy", "torch"]:
         """Get the current backend.

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -185,6 +185,16 @@ class Feature(DeepTrackNode):
         dynamically sample values during pipeline execution. A sampled copy of
         this dictionary is passed to the `get` function and appended to the 
         properties of the output image.
+    float_dtype: np.dtype
+        The data type of the float numbers.
+    int_dtype: np.dtype
+        The data type of the integer numbers.
+    complex_dtype: np.dtype
+        The data type of the complex numbers.
+    bool_dtype: np.dtype
+        The data type of the boolean numbers.
+    device: str | torch.device
+        The device on which the feature is executed.
     __list_merge_strategy__: int
         Specifies how the output of `.get(image, **kwargs)` is merged with the 
         input list. Options include:
@@ -329,6 +339,35 @@ class Feature(DeepTrackNode):
     __gpu_compatible__ = False
 
     _wrap_array_with_image: bool = False
+    _float_dtype: str
+    _int_dtype: str
+    _complex_dtype: str
+    _device: str | torch.device
+
+    @property
+    def float_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the float numbers."""
+        return xp.get_float_dtype(self._float_dtype)
+
+    @property
+    def int_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the integer numbers."""
+        return xp.get_int_dtype(self._int_dtype)
+
+    @property
+    def complex_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the complex numbers."""
+        return xp.get_complex_dtype(self._complex_dtype)
+    
+    @property
+    def bool_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the boolean numbers."""
+        return xp.get_bool_dtype(self._bool_dtype)
+
+    @property
+    def device(self) -> str | torch.device:
+        """The device to be used during evaluation."""
+        return self._device
 
     def __init__(
         self: Feature,
@@ -351,6 +390,14 @@ class Feature(DeepTrackNode):
         """
         # store backend on initialization
         self._backend = config.get_backend()
+
+        # Store the dtype and device on initialization.
+        self._float_dtype = "default"
+        self._int_dtype = "default"
+        self._complex_dtype = "default"
+        self._bool_dtype = "default"
+        self._device = config.get_device()
+
         super().__init__()
 
         # Ensure the feature has a 'name' property; default = class name.
@@ -562,6 +609,50 @@ class Feature(DeepTrackNode):
                     dependency.numpy(recursive=False)
         self.invalidate()
         return self
+
+    def dtype(
+        self: Feature,
+        float: Literal["float32", "float64", "default"] | None = None,
+        int: Literal["int16", "int32", "int64", "default"] | None = None,
+        complex: Literal["complex64", "complex128", "default"] | None = None,
+        bool: Literal["bool", "default"] | None = None,
+    ) -> None:
+        """Set the dtype to be used during evaluation.
+
+        This alters the dtype used for array creation, but does not
+        automatically cast the type.
+
+        Parameters
+        ----------
+        float: str, optional
+            The float dtype to set.
+        int: str, optional
+            The int dtype to set.
+        complex: str, optional
+            The complex dtype to set.
+        bool: str, optional
+            The bool dtype to set.
+        """
+        if float is not None:
+            self._float_dtype = float
+        if int is not None:
+            self._int_dtype = int
+        if complex is not None:
+            self._complex_dtype = complex
+        if bool is not None:
+            self._bool_dtype = bool
+
+    def to(self: Feature, device: str | torch.device):
+        """Set the device to be used during evaluation.
+
+        If the backend is numpy, this can only be "cpu".
+
+        Parameters
+        ----------
+        device: str or torch.device
+            The device to use.
+        """
+        self._device = device
 
     def batch(self: Feature, batch_size: int = 32) -> tuple | list[Image]:
         """Batch the feature.

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -135,7 +135,7 @@ from scipy.spatial.distance import cdist
 
 
 from deeptrack import units
-from deeptrack.backend import config
+from deeptrack.backend import config, xp
 from deeptrack.backend.core import DeepTrackNode
 from deeptrack.backend.units import ConversionTable, create_context
 from deeptrack.image import Image

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -125,7 +125,7 @@ from __future__ import annotations
 import itertools
 import operator
 import random
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Literal
 
 import numpy as np
 import matplotlib.animation as animation


### PR DESCRIPTION
Implements dtype and device on Feature and config.

These should then be used during array creation as xp.zeros((100, 100), dtype=self.float_dtype, device=self.device)

No automatic dtype or device casting happens. We will have to handle this ourselves in the manner described above. 

Current implmentation of torch.random module does not support this syntax. We should make sure it does in a separate PR.

  