### PR TITLE
Bm/implement-math

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "python.testing.unittestArgs": [
+    "-v",
+    "-s",
+    "./deeptrack/tests",
+    "-p",
+    "test_*.py"
+  ],
+  "python.testing.pytestEnabled": false,
+  "python.testing.unittestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,5 @@
 {
-  "python.testing.unittestArgs": [
-    "-v",
-    "-s",
-    "./deeptrack/tests",
-    "-p",
-    "test_*.py"
-  ],
+  "python.testing.unittestArgs": ["-v", "-s", "./deeptrack/tests"],
   "python.testing.pytestEnabled": false,
   "python.testing.unittestEnabled": true
 }

--- a/deeptrack/__init__.py
+++ b/deeptrack/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import lazy_import
+from typing import TYPE_CHECKING
 
 from pint import UnitRegistry
 from .backend.pint_definition import pint_definitions
@@ -20,13 +21,13 @@ if tensorflow_installed:
             "    pip install deeptrack==1.7\n\n"
             "For more details, refer to the DeepTrack documentation."
         ),
-        UserWarning
+        UserWarning,
     )
 
 # Create a unit registry with custom pixel-related units.
 units = UnitRegistry(pint_definitions.split("\n"))
 
-'''# Check if tensorflow is installed without importing it #TBE
+"""# Check if tensorflow is installed without importing it #TBE
 import pkg_resources
 
 installed = [pkg.key for pkg in pkg_resources.working_set]
@@ -42,7 +43,7 @@ else:
     HAS_TORCH = False
 
 if HAS_TENSORFLOW and HAS_TORCH:
-    import torch # torch must be imported before tensorflow'''#TBE
+    import torch # torch must be imported before tensorflow"""  # TBE
 
 from deeptrack.features import *
 from deeptrack.aberrations import *
@@ -60,21 +61,20 @@ from deeptrack.holography import *
 from deeptrack.image import strip
 
 # if not HAS_TENSORFLOW:
-    # Lazy imports to avoid overhead of importing tensorflow
+# Lazy imports to avoid overhead of importing tensorflow
 
-generators = lazy_import.lazy_module("deeptrack.generators")
-models = lazy_import.lazy_module("deeptrack.models")
-datasets = lazy_import.lazy_module("deeptrack.datasets")
-losses = lazy_import.lazy_module("deeptrack.losses")
-layers = lazy_import.lazy_module("deeptrack.layers")
-visualization = lazy_import.lazy_module("deeptrack.visualization")
+# generators = lazy_import.lazy_module("deeptrack.generators")
+# models = lazy_import.lazy_module("deeptrack.models")
+# datasets = lazy_import.lazy_module("deeptrack.datasets")
+# losses = lazy_import.lazy_module("deeptrack.losses")
+# layers = lazy_import.lazy_module("deeptrack.layers")
 
 # if not HAS_TORCH:
 pytorch = lazy_import.lazy_module("deeptrack.pytorch")
 deeplay = lazy_import.lazy_module("deeptrack.deeplay")
 
-should_import = False
-if should_import:
+
+if TYPE_CHECKING:
     from . import generators
     from . import models
     from . import datasets
@@ -83,6 +83,8 @@ if should_import:
     from . import visualization
     from . import pytorch
     from . import deeplay
+
+from deeptrack import tests
 
 from deeptrack import (
     image,

--- a/deeptrack/backend/_config.py
+++ b/deeptrack/backend/_config.py
@@ -101,9 +101,7 @@ class _Proxy(types.ModuleType):
             Name of the proxy object. This is used when printing the object.
 
         """
-
-        self._backend = apcnumpy
-        self._backend_info = apcnumpy.__array_namespace_info__.dtypes()
+        self.set_backend(apcnumpy)
         self.__name__ = name
 
     def set_backend(self: _Proxy, backend: types.ModuleType) -> None:
@@ -117,7 +115,7 @@ class _Proxy(types.ModuleType):
         """
 
         self._backend = backend
-        self._backend_info = backend.__array_namespace_info__.dtypes()
+        self._backend_info = backend.__array_namespace_info__()
 
     def get_float_dtype(self: _Proxy, dtype: str) -> str:
         """Get the float dtype.

--- a/deeptrack/backend/_config.py
+++ b/deeptrack/backend/_config.py
@@ -69,7 +69,7 @@ class _Proxy(types.ModuleType):
     """Keep track of current backend and forward calls to the correct backend.
 
     An instance of this object will be treated as the module `xp`. It acts like
-    a shallow wrapper around the actual backend (for example `numpy` or 
+    a shallow wrapper around the actual backend (for example `numpy` or
     `torch`), and forwards calls to the correct backend.
 
     This is especially useful for array creation functions, to ensure that the
@@ -103,7 +103,69 @@ class _Proxy(types.ModuleType):
         """
 
         self._backend = apcnumpy
+        self._backend_info = apcnumpy.__array_namespace_info__.dtypes()
         self.__name__ = name
+
+    def set_backend(self: _Proxy, backend: types.ModuleType) -> None:
+        """Set the backend to use.
+
+        Parameters
+        ----------
+        backend: types.ModuleType
+            The backend to use.
+
+        """
+
+        self._backend = backend
+        self._backend_info = backend.__array_namespace_info__.dtypes()
+
+    def get_float_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the float dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["real floating"]
+        else:
+            return self._backend_info.dtypes("real floating")[dtype]
+
+    def get_int_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the int dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["integer"]
+        else:
+            return self._backend_info.dtypes("integer")[dtype]
+
+    def get_complex_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the complex dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["complex floating"]
+        else:
+            return self._backend_info.dtypes("complex floating")[dtype]
+
+    def get_bool_dtype(self: _Proxy, dtype: str) -> str:
+        """Get the bool dtype.
+
+        Returns
+        -------
+        str
+        """
+        if dtype == "default":
+            return self._backend_info.default_dtypes["bool"]
+        else:
+            return self._backend_info.dtypes("bool")[dtype]
 
     def __getattr__(self: _Proxy, attribute: str) -> Any:
         """Forward attribute access to the current backend.
@@ -209,7 +271,7 @@ class Config:
         Can be a string, most typically "cpu", "gpu", "cuda", "mps", or
         torch.device. In any case, it needs to be used with a compatible
         backend.
-        
+
         It can only be "cpu" when using NumPy backend.
 
         Parameters
@@ -263,7 +325,7 @@ class Config:
             from deeptrack.backend import array_api_compat_ext
 
         self.backend = backend
-        xp._backend = importlib.import_module(f"array_api_compat.{backend}")
+        xp.set_backend(importlib.import_module(f"array_api_compat.{backend}"))
 
     def get_backend(self: Config) -> Literal["numpy", "torch"]:
         """Get the current backend.

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -185,6 +185,16 @@ class Feature(DeepTrackNode):
         dynamically sample values during pipeline execution. A sampled copy of
         this dictionary is passed to the `get` function and appended to the 
         properties of the output image.
+    float_dtype: np.dtype
+        The data type of the float numbers.
+    int_dtype: np.dtype
+        The data type of the integer numbers.
+    complex_dtype: np.dtype
+        The data type of the complex numbers.
+    bool_dtype: np.dtype
+        The data type of the boolean numbers.
+    device: str | torch.device
+        The device on which the feature is executed.
     __list_merge_strategy__: int
         Specifies how the output of `.get(image, **kwargs)` is merged with the 
         input list. Options include:
@@ -329,6 +339,35 @@ class Feature(DeepTrackNode):
     __gpu_compatible__ = False
 
     _wrap_array_with_image: bool = False
+    _float_dtype: str
+    _int_dtype: str
+    _complex_dtype: str
+    _device: str | torch.device
+
+    @property
+    def float_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the float numbers."""
+        return xp.get_float_dtype(self._float_dtype)
+
+    @property
+    def int_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the integer numbers."""
+        return xp.get_int_dtype(self._int_dtype)
+
+    @property
+    def complex_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the complex numbers."""
+        return xp.get_complex_dtype(self._complex_dtype)
+    
+    @property
+    def bool_dtype(self) -> np.dtype | torch.dtype:
+        """The dtype of the boolean numbers."""
+        return xp.get_bool_dtype(self._bool_dtype)
+
+    @property
+    def device(self) -> str | torch.device:
+        """The device to be used during evaluation."""
+        return self._device
 
     def __init__(
         self: Feature,
@@ -351,6 +390,14 @@ class Feature(DeepTrackNode):
         """
         # store backend on initialization
         self._backend = config.get_backend()
+
+        # Store the dtype and device on initialization.
+        self._float_dtype = "default"
+        self._int_dtype = "default"
+        self._complex_dtype = "default"
+        self._bool_dtype = "default"
+        self._device = config.get_device()
+
         super().__init__()
 
         # Ensure the feature has a 'name' property; default = class name.
@@ -562,6 +609,50 @@ class Feature(DeepTrackNode):
                     dependency.numpy(recursive=False)
         self.invalidate()
         return self
+
+    def dtype(
+        self: Feature,
+        float: Literal["float32", "float64", "default"] | None = None,
+        int: Literal["int16", "int32", "int64", "default"] | None = None,
+        complex: Literal["complex64", "complex128", "default"] | None = None,
+        bool: Literal["bool", "default"] | None = None,
+    ) -> None:
+        """Set the dtype to be used during evaluation.
+
+        This alters the dtype used for array creation, but does not
+        automatically cast the type.
+
+        Parameters
+        ----------
+        float: str, optional
+            The float dtype to set.
+        int: str, optional
+            The int dtype to set.
+        complex: str, optional
+            The complex dtype to set.
+        bool: str, optional
+            The bool dtype to set.
+        """
+        if float is not None:
+            self._float_dtype = float
+        if int is not None:
+            self._int_dtype = int
+        if complex is not None:
+            self._complex_dtype = complex
+        if bool is not None:
+            self._bool_dtype = bool
+
+    def to(self: Feature, device: str | torch.device):
+        """Set the device to be used during evaluation.
+
+        If the backend is numpy, this can only be "cpu".
+
+        Parameters
+        ----------
+        device: str or torch.device
+            The device to use.
+        """
+        self._device = device
 
     def batch(self: Feature, batch_size: int = 32) -> tuple | list[Image]:
         """Batch the feature.

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -135,7 +135,7 @@ from scipy.spatial.distance import cdist
 
 
 from deeptrack import units
-from deeptrack.backend import config
+from deeptrack.backend import config, xp
 from deeptrack.backend.core import DeepTrackNode
 from deeptrack.backend.units import ConversionTable, create_context
 from deeptrack.image import Image

--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -125,7 +125,7 @@ from __future__ import annotations
 import itertools
 import operator
 import random
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Literal
 
 import numpy as np
 import matplotlib.animation as animation

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -211,7 +211,7 @@ class Average(Feature):
         """
         if self.features is not None:
             images = [feature.resolve() for feature in self.features]
-        result = xp.mean(images, axis=axis)
+        result = xp.mean(xp.stack(images), axis=axis)
 
         return result
 

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -89,7 +89,7 @@ Process an input image:
 """
 
 from __future__ import annotations
-from typing import Callable, Any, List
+from typing import TYPE_CHECKING, Callable, Any, List
 
 import numpy as np
 import scipy.ndimage as ndimage
@@ -101,6 +101,9 @@ from deeptrack.features import Feature
 from deeptrack.image import Image, strip
 from deeptrack.types import ArrayLike, PropertyLike
 from deeptrack.backend import xp
+
+if TYPE_CHECKING:
+    import torch
 
 
 class Average(Feature):
@@ -770,9 +773,89 @@ class AverageBlur(Blur):
 
         super().__init__(None, ksize=ksize, **kwargs)
 
+    def _kernel_shape(self, shape: tuple[int, ...], ksize: int) -> tuple[int, ...]:
+        if shape[-1] < ksize:
+            return (ksize,) * (len(shape) - 1) + (1,)
+        return (ksize,) * len(shape)
+
+    def _get_numpy(
+        self, input: np.ndarray, ksize: tuple[int, ...], **kwargs: Any
+    ) -> np.ndarray:
+        return ndimage.uniform_filter(
+            input,
+            size=ksize,
+            mode=kwargs.get("mode", "reflect"),
+            cval=kwargs.get("cval", 0),
+            origin=kwargs.get("origin", 0),
+            axes=tuple(range(0, len(ksize))),
+        )
+
+    def _get_torch(
+        self, input: torch.Tensor, ksize: tuple[int, ...], **kwargs: Any
+    ) -> np.ndarray:
+        F = xp.nn.functional
+
+        last_dim_is_channel = len(ksize) < input.ndim
+        if last_dim_is_channel:
+            # permute to first dim
+            input = input.movedim(-1, 0)
+        else:
+            input = input.unsqueeze(0)
+
+        # add batch dimension
+        input = input.unsqueeze(0)
+
+        # pad input
+        input = F.pad(
+            input,
+            (ksize[0] // 2, ksize[0] // 2, ksize[1] // 2, ksize[1] // 2),
+            mode=kwargs.get("mode", "reflect"),
+            value=kwargs.get("cval", 0),
+        )
+        if input.ndim == 3:
+            x = F.avg_pool1d(
+                input,
+                kernel_size=ksize,
+                stride=1,
+                padding=0,
+                ceil_mode=False,
+                count_include_pad=False,
+            )
+        elif input.ndim == 4:
+            x = F.avg_pool2d(
+                input,
+                kernel_size=ksize,
+                stride=1,
+                padding=0,
+                ceil_mode=False,
+                count_include_pad=False,
+            )
+        elif input.ndim == 5:
+            x = F.avg_pool3d(
+                input,
+                kernel_size=ksize,
+                stride=1,
+                padding=0,
+                ceil_mode=False,
+                count_include_pad=False,
+            )
+        else:
+            raise NotImplementedError(
+                f"Input dimension {input.ndim - 2} not supported for torch backend"
+            )
+
+        # restore layout
+        x = x.squeeze(0)
+        if last_dim_is_channel:
+            x = x.movedim(0, -1)
+        else:
+            x = x.squeeze(0)
+
+        return x
+
     def get(
         self: AverageBlur,
-        input: np.ndarray | Image,
+        input: ArrayLike,
         ksize: int,
         **kwargs: Any,
     ) -> np.ndarray:
@@ -796,19 +879,14 @@ class AverageBlur(Blur):
 
         """
 
-        if input.shape[-1] < ksize:
-            ksize = (ksize,) * (input.ndim - 1) + (1,)
+        k = self._kernel_shape(input.shape, ksize)
+
+        if self.backend == "numpy":
+            return self._get_numpy(input, k, **kwargs)
+        elif self.backend == "torch":
+            return self._get_torch(input, k, **kwargs)
         else:
-            ksize = ((ksize,) * input.ndim,)
-
-        weights = np.ones(ksize) / np.prod(ksize)
-
-        return utils.safe_call(
-            ndimage.convolve,
-            input=input,
-            weights=weights,
-            **kwargs,
-        )
+            raise NotImplementedError(f"Backend {self.backend} not supported")
 
 
 class GaussianBlur(Blur):

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1,11 +1,11 @@
 """Mathematical operations and structures.
 
-This module provides classes and utilities to perform common mathematical 
-operations and transformations on images, including clipping, normalization, 
-blurring, and pooling. These are implemented as subclasses of `Feature` for 
-seamless integration with the feature-based design of the library. Each 
-`Feature` supports lazy evaluation and can be composed using operators (e.g., 
-`>>` for chaining), enabling efficient and readable construction of image 
+This module provides classes and utilities to perform common mathematical
+operations and transformations on images, including clipping, normalization,
+blurring, and pooling. These are implemented as subclasses of `Feature` for
+seamless integration with the feature-based design of the library. Each
+`Feature` supports lazy evaluation and can be composed using operators (e.g.,
+`>>` for chaining), enabling efficient and readable construction of image
 processing pipelines.
 
 Key Features
@@ -19,11 +19,11 @@ Key Features
     Adjust image values to a common scale.
 
 - **Blurring**
-    
+
     Smooth images using various filters.
 
 - **Pooling**
-    
+
     Downsample images by applying a function to local regions.
 
 - **Resizing**
@@ -38,7 +38,7 @@ Classes:
 
 - `NormalizeMinMax`: Perform min-max normalization on images.
 
-- `NormalizeStandard`: Normalize images to have mean 0 and standard 
+- `NormalizeStandard`: Normalize images to have mean 0 and standard
     deviation 1.
 
 - `NormalizeQuantile`: Normalize images based on specified quantiles.
@@ -89,7 +89,7 @@ Process an input image:
 """
 
 from __future__ import annotations
-from typing import Callable, Any
+from typing import Callable, Any, List
 
 import numpy as np
 import scipy.ndimage as ndimage
@@ -99,14 +99,15 @@ import skimage.measure
 from deeptrack import utils
 from deeptrack.features import Feature
 from deeptrack.image import Image, strip
-from deeptrack.types import PropertyLike
+from deeptrack.types import ArrayLike, PropertyLike
+from deeptrack.backend import xp
 
 
 class Average(Feature):
     """Average of input images.
 
-    This class computes the average of input images along the specified axis. 
-    If `features` is not None, it instead resolves all features in the list and 
+    This class computes the average of input images along the specified axis.
+    If `features` is not None, it instead resolves all features in the list and
     averages the result.
 
     Parameters
@@ -118,10 +119,10 @@ class Average(Feature):
     Attributes
     ----------
     __distributed__: bool
-        Determines whether `.get(image, **kwargs)` is applied to each element 
-        of the input list independently (`__distributed__ = True`) or to the 
+        Determines whether `.get(image, **kwargs)` is applied to each element
+        of the input list independently (`__distributed__ = True`) or to the
         list as a whole (`__distributed__ = False`).
-     
+
     Methods
     -------
     `get(images: np.ndarray | Image | list[Image], axis: int, **kwargs: Any) --> np.ndarray`
@@ -131,7 +132,7 @@ class Average(Feature):
     --------
     >>> import deeptrack as dt
     >>> import numpy as np
-    
+
     Create two input images:
     >>> input_image1 = np.random.rand(10, 30, 20)
     >>> input_image2 = np.random.rand(10, 30, 20)
@@ -144,9 +145,9 @@ class Average(Feature):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
@@ -157,11 +158,11 @@ class Average(Feature):
         self: Average,
         features: PropertyLike[list[Feature] | None] = None,
         axis: PropertyLike[int] = 0,
-        **kwargs: Any
+        **kwargs: Any,
     ):
-        """Initialize the parameters for averaging input features. 
-        
-        This constructor initializes the parameters for averaging input 
+        """Initialize the parameters for averaging input features.
+
+        This constructor initializes the parameters for averaging input
         features.
 
         Parameters
@@ -182,14 +183,14 @@ class Average(Feature):
             self.features = [self.add_feature(f) for f in features]
 
     def get(
-        self: Average, 
-        images: np.ndarray | Image | list[Image],
+        self: Average,
+        images: ArrayLike | List[ArrayLike],
         axis: int,
         **kwargs: Any,
-    ) -> np.ndarray:
+    ) -> ArrayLike:
         """Computes the average of input images along the specified axis.
 
-        This method computes the average of the input images along the 
+        This method computes the average of the input images along the
         specified axis.
 
         Parameters
@@ -207,10 +208,7 @@ class Average(Feature):
         """
         if self.features is not None:
             images = [feature.resolve() for feature in self.features]
-        result = Image(np.mean(images, axis=axis))
-
-        for image in images:
-            result.merge_properties_from(image)
+        result = xp.mean(images, axis=axis)
 
         return result
 
@@ -240,7 +238,7 @@ class Clip(Feature):
 
     Create an input image:
     >>> input_image = np.array([[10, 4], [4, -10]])
-    
+
     Define a clipper feature:
     >>> clipper = dt.Clip(min=0, max=5)
     >>> output_image = clipper(input_image)
@@ -250,9 +248,9 @@ class Clip(Feature):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
@@ -281,10 +279,10 @@ class Clip(Feature):
         super().__init__(min=min, max=max, **kwargs)
 
     def get(
-        self: Clip, 
-        image: np.ndarray | Image, 
-        min: float = None, 
-        max: float = None, 
+        self: Clip,
+        image: ArrayLike,
+        min: float = None,
+        max: float = None,
         **kwargs: Any,
     ) -> np.ndarray:
         """Clips the input image within the specified values.
@@ -308,7 +306,7 @@ class Clip(Feature):
 
         """
 
-        return np.clip(image, min, max)
+        return xp.clip(image, min, max)
 
 
 class NormalizeMinMax(Feature):
@@ -329,7 +327,7 @@ class NormalizeMinMax(Feature):
     Methods
     -------
     `get(image: np.ndarray | Image, min: float, max: float, **kwargs: Any) --> np.ndarray`
-        Normalizes the input image to be between the specified minimum and 
+        Normalizes the input image to be between the specified minimum and
         maximum values.
 
     Examples
@@ -349,9 +347,9 @@ class NormalizeMinMax(Feature):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
@@ -383,13 +381,13 @@ class NormalizeMinMax(Feature):
         super().__init__(min=min, max=max, featurewise=featurewise, **kwargs)
 
     def get(
-        self: NormalizeMinMax, 
-        image: np.ndarray | Image, 
-        min: float = None, 
-        max: float = None, 
+        self: NormalizeMinMax,
+        image: ArrayLike,
+        min: float = None,
+        max: float = None,
         **kwargs: Any,
-    ) -> np.ndarray:
-        """Normalizes the input image to be between the specified minimum and 
+    ) -> ArrayLike:
+        """Normalizes the input image to be between the specified minimum and
         maximum values.
 
         This method normalizes the input image to be between the specified
@@ -410,11 +408,11 @@ class NormalizeMinMax(Feature):
             The normalized image.
 
         """
-
-        image = image / np.ptp(image) * (max - min)
-        image = image - np.min(image) + min
+        ptp = xp.max(image) - xp.min(image)
+        image = image / ptp * (max - min)
+        image = image - xp.min(image) + min
         try:
-            image[np.isnan(image)] = 0
+            image[xp.isnan(image)] = 0
         except TypeError:
             pass
         return image
@@ -433,7 +431,7 @@ class NormalizeStandard(Feature):
     Methods
     -------
     `get(image: np.ndarray | Image, **kwargs: Any) --> np.ndarray`
-        Normalizes (standardizes) the input image to have mean 0 and standard 
+        Normalizes (standardizes) the input image to have mean 0 and standard
         deviation 1.
 
     Examples
@@ -443,7 +441,7 @@ class NormalizeStandard(Feature):
 
     Create an input image:
     >>> input_image = np.array([[1, 2], [3, 4]], dtype=float)
-    
+
     >>> standardizer = dt.NormalizeStandard()
     >>> output_image = standardizer(input_image)
     >>> print(output_image)
@@ -452,15 +450,15 @@ class NormalizeStandard(Feature):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
 
     def __init__(
-        self:NormalizeStandard,
+        self: NormalizeStandard,
         featurewise: bool = True,
         **kwargs: Any,
     ):
@@ -480,9 +478,9 @@ class NormalizeStandard(Feature):
 
     def get(
         self: NormalizeStandard,
-        image: np.ndarray | Image, 
+        image: ArrayLike,
         **kwargs: Any,
-    ) -> np.ndarray:
+    ) -> ArrayLike:
         """Normalizes the input image to have mean 0 and standard deviation 1.
 
         This method normalizes the input image to have mean 0 and standard
@@ -500,7 +498,7 @@ class NormalizeStandard(Feature):
 
         """
 
-        return (image - np.mean(image)) / np.std(image)
+        return (image - xp.mean(image)) / xp.std(image)
 
 
 class NormalizeQuantile(Feature):
@@ -538,15 +536,15 @@ class NormalizeQuantile(Feature):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
 
     def __init__(
-        self: NormalizeQuantile, 
+        self: NormalizeQuantile,
         quantiles: tuple[float, float] = (0.25, 0.75),
         featurewise: bool = True,
         **kwargs: Any,
@@ -566,20 +564,17 @@ class NormalizeQuantile(Feature):
 
         """
 
-        super().__init__(
-            quantiles=quantiles, 
-            featurewise=featurewise, 
-            **kwargs)
+        super().__init__(quantiles=quantiles, featurewise=featurewise, **kwargs)
 
     def get(
         self: NormalizeQuantile,
-        image: np.ndarray | Image,
+        image: ArrayLike,
         quantiles: tuple[float, float] = None,
         **kwargs: Any,
-    ) -> np.ndarray:
+    ) -> ArrayLike:
         """Normalizes the input image based on the specified quantiles.
 
-        This method normalizes the input image based on the specified 
+        This method normalizes the input image based on the specified
         quantiles.
 
         Parameters
@@ -597,8 +592,9 @@ class NormalizeQuantile(Feature):
         """
 
         if quantiles is None:
+            # Why is this here?
             quantiles = self.quantiles
-        q_low, q_high, median = np.quantile(image, (*quantiles, 0.5))
+        q_low, q_high, median = xp.quantile(image, (*quantiles, 0.5))
         return (image - median) / (q_high - q_low)
 
 
@@ -612,8 +608,8 @@ class Blur(Feature):
     Parameters
     ----------
     filter_function: Callable
-        The blurring function to apply. This function must accept the input 
-        image as a keyword argument named `input`. If using OpenCV functions 
+        The blurring function to apply. This function must accept the input
+        image as a keyword argument named `input`. If using OpenCV functions
         (e.g., `cv2.GaussianBlur`), use `BlurCV2` instead.
     mode: str
         Border mode for handling boundaries (e.g., 'reflect').
@@ -628,7 +624,7 @@ class Blur(Feature):
     >>> import deeptrack as dt
     >>> import numpy as np
     >>> from scipy.ndimage import convolve
-    
+
     Create an input image:
     >>> input_image = np.random.rand(32, 32)
 
@@ -641,27 +637,27 @@ class Blur(Feature):
     ...     [1,  4,  6,  4, 1]
     ... ], dtype=float)
     >>> gaussian_kernel /= np.sum(gaussian_kernel)
-    
+
 
     Define a blur function using the Gaussian kernel:
     >>> def gaussian_blur(input, **kwargs):
     ...     return convolve(input, gaussian_kernel, mode='reflect')
 
     Define a blur feature using the Gaussian blur function:
-    >>> blur = dt.Blur(filter_function=gaussian_blur)   
+    >>> blur = dt.Blur(filter_function=gaussian_blur)
     >>> output_image = blur(input_image)
     >>> print(output_image.shape)
     (32, 32)
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
-    The filter_function must accept the input image as a keyword argument named 
-    input. This is required because it is called via utils.safe_call. If you 
-    are using functions that do not support input=... (such as OpenCV filters 
+    The filter_function must accept the input image as a keyword argument named
+    input. This is required because it is called via utils.safe_call. If you
+    are using functions that do not support input=... (such as OpenCV filters
     like cv2.GaussianBlur), consider using BlurCV2 instead.
 
     """
@@ -674,7 +670,7 @@ class Blur(Feature):
     ):
         """Initialize the parameters for blurring input features.
 
-        This constructor initializes the parameters for blurring input 
+        This constructor initializes the parameters for blurring input
         features.
 
         Parameters
@@ -691,11 +687,7 @@ class Blur(Feature):
         self.filter = filter_function
         super().__init__(borderType=mode, **kwargs)
 
-    def get(
-        self: Blur, 
-        image: np.ndarray | Image, 
-        **kwargs: Any
-    ) -> np.ndarray:
+    def get(self: Blur, image: np.ndarray | Image, **kwargs: Any) -> np.ndarray:
         """Applies the blurring filter to the input image.
 
         This method applies the blurring filter to the input image.
@@ -750,15 +742,15 @@ class AverageBlur(Blur):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
 
     def __init__(
-        self: AverageBlur, 
+        self: AverageBlur,
         ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
@@ -801,7 +793,7 @@ class AverageBlur(Blur):
         -------
         np.ndarray
             The blurred image.
-             
+
         """
 
         if input.shape[-1] < ksize:
@@ -816,7 +808,7 @@ class AverageBlur(Blur):
             input=input,
             weights=weights,
             **kwargs,
-            )
+        )
 
 
 class GaussianBlur(Blur):
@@ -845,7 +837,7 @@ class GaussianBlur(Blur):
     >>> output_image = gaussian_blur(input_image)
     >>> print(output_image.shape)
     (32, 32)
-    
+
     Visualize the input and output images:
     >>> plt.figure(figsize=(8, 4))
     >>> plt.subplot(1, 2, 1)
@@ -863,11 +855,7 @@ class GaussianBlur(Blur):
 
     """
 
-    def __init__(
-        self: GaussianBlur, 
-        sigma: PropertyLike[float] = 2, 
-        **kwargs: Any
-    ):
+    def __init__(self: GaussianBlur, sigma: PropertyLike[float] = 2, **kwargs: Any):
         """Initialize the parameters for Gaussian blurring.
 
         This constructor initializes the parameters for Gaussian blurring.
@@ -878,19 +866,19 @@ class GaussianBlur(Blur):
             Standard deviation of the Gaussian kernel.
         **kwargs: Any
             Additional keyword arguments.
-        
+
         """
 
         super().__init__(ndimage.gaussian_filter, sigma=sigma, **kwargs)
 
 
 class MedianBlur(Blur):
-    """Applies a median blur. 
-    
+    """Applies a median blur.
+
     This class replaces each pixel of the input image with the median value of
-    its neighborhood. The `ksize` parameter determines the size of the 
-    neighborhood used to calculate the median filter. The median filter is 
-    useful for reducing noise while preserving edges. It is particularly 
+    its neighborhood. The `ksize` parameter determines the size of the
+    neighborhood used to calculate the median filter. The median filter is
+    useful for reducing noise while preserving edges. It is particularly
     effective for removing salt-and-pepper noise from images.
 
     Parameters
@@ -908,7 +896,7 @@ class MedianBlur(Blur):
 
     Create an input image:
     >>> input_image = np.random.rand(32, 32)
-    
+
     Define a median blur feature:
     >>> median_blur = dt.MedianBlur(ksize=3)
     >>> output_image = median_blur(input_image)
@@ -940,16 +928,16 @@ class MedianBlur(Blur):
         """Initialize the parameters for median blurring.
 
         This constructor initializes the parameters for median blurring.
-        
+
         Parameters
         ----------
         ksize: int
             Kernel size.
         **kwargs: Any
             Additional keyword arguments.
-        
+
         """
-        
+
         super().__init__(ndimage.median_filter, size=ksize, **kwargs)
 
 
@@ -959,8 +947,8 @@ class Pool(Feature):
 
     This class reduces the resolution of an image by dividing it into
     non-overlapping blocks of size `ksize` and applying the specified pooling
-    function to each block. The result is a downsampled image where each pixel 
-    value represents the result of the pooling function applied to the 
+    function to each block. The result is a downsampled image where each pixel
+    value represents the result of the pooling function applied to the
     corresponding block.
 
     Parameters
@@ -968,7 +956,7 @@ class Pool(Feature):
     pooling_function: function
         A function that is applied to each local region of the image.
         DOES NOT NEED TO BE WRAPPED IN ANOTHER FUNCTION.
-        The `pooling_function` must accept the input image as a keyword argument 
+        The `pooling_function` must accept the input image as a keyword argument
         named `input`, as it is called via `utils.safe_call`.
         Examples include `np.mean`, `np.max`, `np.min`, etc.
     ksize: int
@@ -994,16 +982,16 @@ class Pool(Feature):
     >>> output_image = pooling_feature.get(input_image, ksize=4)
     >>> print(output_image.shape)
     (8, 8)
-    
+
     Notes
     -----
     Calling this feature returns a `np.ndarray` by default. If
     `store_properties` is set to `True`, the returned array will be
     automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
-    The filter_function must accept the input image as a keyword argument named 
-    input. This is required because it is called via utils.safe_call. If you 
-    are using functions that do not support input=... (such as OpenCV filters 
+    The filter_function must accept the input image as a keyword argument named
+    input. This is required because it is called via utils.safe_call. If you
+    are using functions that do not support input=... (such as OpenCV filters
     like cv2.GaussianBlur), consider using BlurCV2 instead.
 
     """
@@ -1040,9 +1028,9 @@ class Pool(Feature):
         **kwargs: Any,
     ) -> np.ndarray:
         """Applies the pooling function to the input image.
-        
+
         This method applies the pooling function to the input image.
-        
+
         Parameters
         ----------
         image: np.ndarray
@@ -1051,14 +1039,14 @@ class Pool(Feature):
             Size of the pooling kernel.
         **kwargs: dict[str, Any]
             Additional keyword arguments.
-        
+
         Returns
         -------
         np.ndarray
             The pooled image.
-        
+
         """
-        
+
         kwargs.pop("func", False)
         kwargs.pop("image", False)
         kwargs.pop("block_size", False)
@@ -1074,11 +1062,11 @@ class Pool(Feature):
 class AveragePooling(Pool):
     """Apply average pooling to an image.
 
-    This class reduces the resolution of an image by dividing it into 
+    This class reduces the resolution of an image by dividing it into
     non-overlapping blocks of size `ksize` and applying the average function to
-    each block. The result is a downsampled image where each pixel value 
+    each block. The result is a downsampled image where each pixel value
     represents the average value within the corresponding block of the
-    original image. 
+    original image.
 
     Parameters
     ----------
@@ -1094,7 +1082,7 @@ class AveragePooling(Pool):
 
     Create an input image:
     >>> input_image = np.random.rand(32, 32)
-    
+
     Define an average pooling feature:
     >>> average_pooling = dt.AveragePooling(ksize=4)
     >>> output_image = average_pooling(input_image)
@@ -1111,14 +1099,14 @@ class AveragePooling(Pool):
     """
 
     def __init__(
-        self: Pool, 
-        ksize: PropertyLike[int] = 3, 
+        self: Pool,
+        ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
         """Initialize the parameters for average pooling.
 
         This constructor initializes the parameters for average pooling.
-        
+
         Parameters
         ----------
         ksize: int
@@ -1163,7 +1151,7 @@ class MaxPooling(Pool):
     >>> output_image = max_pooling(input_image)
     >>> print(output_image.shape)
     (8, 8)
-    
+
     Notes
     -----
     Calling this feature returns a `np.ndarray` by default. If
@@ -1174,21 +1162,21 @@ class MaxPooling(Pool):
     """
 
     def __init__(
-        self: MaxPooling, 
+        self: MaxPooling,
         ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
         """Initialize the parameters for max pooling.
 
         This constructor initializes the parameters for max pooling.
-        
+
         Parameters
         ----------
         ksize: int
             Size of the pooling kernel.
         **kwargs: Any
             Additional keyword arguments.
-        
+
         """
 
         super().__init__(np.max, ksize=ksize, **kwargs)
@@ -1234,14 +1222,14 @@ class MinPooling(Pool):
     """
 
     def __init__(
-        self: MinPooling, 
-        ksize: PropertyLike[int] = 3, 
+        self: MinPooling,
+        ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
         """Initialize the parameters for min pooling.
 
         This constructor initializes the parameters for min pooling.
-        
+
         Parameters
         ----------
         ksize: int
@@ -1275,7 +1263,7 @@ class MedianPooling(Pool):
     --------
     >>> import deeptrack as dt
     >>> import numpy as np
-    
+
     Create an input image:
     >>> input_image = np.random.rand(32, 32)
 
@@ -1295,22 +1283,22 @@ class MedianPooling(Pool):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
 
     def __init__(
-        self: MedianPooling, 
-        ksize: PropertyLike[int] = 3, 
+        self: MedianPooling,
+        ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
         """Initialize the parameters for median pooling.
 
         This constructor initializes the parameters for median pooling.
-        
+
         Parameters
         ----------
         ksize: int
@@ -1325,9 +1313,9 @@ class MedianPooling(Pool):
 
 class Resize(Feature):
     """Resize an image to a specified size.
-    
-    This class is a wrapper around cv2.resize and resizes an image to a 
-    specified size. The `dsize` parameter specifies the desired output size of 
+
+    This class is a wrapper around cv2.resize and resizes an image to a
+    specified size. The `dsize` parameter specifies the desired output size of
     the image.
     Note that the order of the axes is different in cv2 and numpy. In cv2, the
     first axis is the vertical axis, while in numpy it is the horizontal axis.
@@ -1343,7 +1331,7 @@ class Resize(Feature):
     """
 
     def __init__(
-        self: Resize, 
+        self: Resize,
         dsize: PropertyLike[tuple] = (256, 256),
         **kwargs: Any,
     ):
@@ -1360,17 +1348,12 @@ class Resize(Feature):
             Additional keyword arguments.
 
         """
-        
+
         super().__init__(dsize=dsize, **kwargs)
 
-    def get(
-        self: Resize,
-        image: np.ndarray,  
-        dsize: tuple,
-        **kwargs: Any
-    ) -> np.ndarray:
+    def get(self: Resize, image: np.ndarray, dsize: tuple, **kwargs: Any) -> np.ndarray:
         """Resize the input image to the specified size.
-        
+
         This method resizes the input image to the specified size.
 
         Parameters
@@ -1381,7 +1364,7 @@ class Resize(Feature):
             Desired output size of the image.
         **kwargs: Any
             Additional keyword arguments.
-        
+
         Returns
         -------
         np.ndarray
@@ -1395,9 +1378,7 @@ class Resize(Feature):
         if self._wrap_array_with_image:
             image = strip(image)
 
-        return utils.safe_call(
-            cv2.resize, positional_args=[image, dsize], **kwargs
-        )
+        return utils.safe_call(cv2.resize, positional_args=[image, dsize], **kwargs)
 
 
 try:
@@ -1419,8 +1400,8 @@ except ImportError:
 class BlurCV2(Feature):
     """Apply a blurring filter using OpenCV2.
 
-    This class applies a blurring filter to an image using OpenCV2. The 
-    filter_function must be an OpenCV-compatible function that accepts a src 
+    This class applies a blurring filter to an image using OpenCV2. The
+    filter_function must be an OpenCV-compatible function that accepts a src
     keyword argument (e.g., cv2.GaussianBlur, cv2.bilateralFilter, etc.).
 
     Parameters
@@ -1429,7 +1410,7 @@ class BlurCV2(Feature):
         The blurring function to apply.
     mode: str
         Border mode for handling boundaries (e.g., 'reflect').
-    
+
     Methods
     -------
     `get(image: np.ndarray | Image, **kwargs: Any) --> np.ndarray`
@@ -1446,34 +1427,34 @@ class BlurCV2(Feature):
 
     Define a blur feature using the Gaussian blur function:
     >>> blur = dt.BlurCV2(
-    ...     filter_function=cv2.GaussianBlur, 
-    ...     ksize=(5, 5), 
-    ...     sigmaX=1, 
+    ...     filter_function=cv2.GaussianBlur,
+    ...     ksize=(5, 5),
+    ...     sigmaX=1,
     ...     mode='reflect',
     ... )
     >>> output_image = blur(input_image)
     >>> print(output_image.shape)
     (32, 32)
-    
+
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
 
     """
-    
+
     def __new__(
-        cls: type, 
+        cls: type,
         *args: tuple,
         **kwargs: Any,
     ):
-        """Ensures that OpenCV (cv2) is available before instantiating the 
+        """Ensures that OpenCV (cv2) is available before instantiating the
         class.
 
-        Overrides the default object creation process to check that the `cv2` 
-        module is available before creating the class. If OpenCV is not 
+        Overrides the default object creation process to check that the `cv2`
+        module is available before creating the class. If OpenCV is not
         installed, it raises an ImportError with instructions for installation.
 
         Parameters
@@ -1491,9 +1472,9 @@ class BlurCV2(Feature):
         Raises
         ------
         ImportError
-            If the OpenCV (`cv2`) module is not available in the current 
+            If the OpenCV (`cv2`) module is not available in the current
             environment.
-    
+
         """
 
         if not IMPORTED_CV2:
@@ -1531,14 +1512,14 @@ class BlurCV2(Feature):
         super().__init__(borderType=borderType, **kwargs)
 
     def get(
-        self: BlurCV2, 
+        self: BlurCV2,
         image: np.ndarray | Image,
         **kwargs: Any,
-    )  -> np.ndarray:
+    ) -> np.ndarray:
         """Applies the blurring filter to the input image.
 
         This method applies the blurring filter to the input image.
-        
+
         Parameters
         ----------
         image: np.ndarray | Image
@@ -1552,8 +1533,8 @@ class BlurCV2(Feature):
             The blurred image.
 
         """
-        
-        kwargs.pop("name", None)        
+
+        kwargs.pop("name", None)
         result = self.filter(src=image, **kwargs)
         return result
 
@@ -1580,7 +1561,7 @@ class BilateralBlur(BlurCV2):
         `sigma_color`).
     **kwargs: dict
         Additional parameters sent to the blurring function.
-      
+
     Examples
     --------
     >>> import deeptrack as dt
@@ -1603,11 +1584,11 @@ class BilateralBlur(BlurCV2):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If 
-    `store_properties` is set to `True`, the returned array will be 
-    automatically wrapped in an `Image` object. This behavior is handled 
+    Calling this feature returns a `np.ndarray` by default. If
+    `store_properties` is set to `True`, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
     internally and does not affect the return type of the `get()` method.
-    
+
     """
 
     def __init__(
@@ -1620,7 +1601,7 @@ class BilateralBlur(BlurCV2):
         """Initialize the parameters for bilateral blurring.
 
         This constructor initializes the parameters for bilateral blurring.
-        
+
         Parameters
         ----------
         d: int
@@ -1646,4 +1627,3 @@ class BilateralBlur(BlurCV2):
             sigmaSpace=sigma_space,
             **kwargs,
         )
-

--- a/deeptrack/tests/__init__.py
+++ b/deeptrack/tests/__init__.py
@@ -11,11 +11,3 @@ class BackendTestBase(unittest.TestCase):
         if cls.BACKEND is None:
             raise ValueError("BACKEND not set")
         config.set_backend(cls.BACKEND)
-
-
-class TorchBackendMixin(BackendTestBase):
-    BACKEND = "torch"
-
-
-class NumpyBackendMixin(BackendTestBase):
-    BACKEND = "numpy"

--- a/deeptrack/tests/__init__.py
+++ b/deeptrack/tests/__init__.py
@@ -1,16 +1,21 @@
-#from .backend import *
-#from .extras import *
+from pathlib import Path
+import unittest
+from deeptrack.backend import config  # adjust to real import path
 
-#from .test_aberrations import *
-#from .test_augmentations import *
-#from .test_elementwise import *
-#from .test_features import *
-#from .test_image import *
-#from .test_math import *
-#from .test_noises import *
-#from .test_optics import *
-#from .test_properties import *
-#from .test_scatterers import *
-#from .test_sequences import *
-#from .test_statistics import *
-#from .test_utils import *
+
+class BackendTestBase(unittest.TestCase):
+    BACKEND = None
+
+    @classmethod
+    def setUpClass(cls):
+        if cls.BACKEND is None:
+            raise ValueError("BACKEND not set")
+        config.set_backend(cls.BACKEND)
+
+
+class TorchBackendMixin(BackendTestBase):
+    BACKEND = "torch"
+
+
+class NumpyBackendMixin(BackendTestBase):
+    BACKEND = "numpy"

--- a/deeptrack/tests/backend/test_polynomials.py
+++ b/deeptrack/tests/backend/test_polynomials.py
@@ -22,59 +22,50 @@ class TestPolynomials(unittest.TestCase):
         self.assertEqual(Besselj(1, 5), -Besselj(-1, 5))
         self.assertTrue(Besselj(1, 5) < 0)
 
-
     def test_dBesselj(self):
         dBesselj = polynomials.dbesselj
 
-        self.assertEqual(dBesselj(1,0), 0.5)
-
+        self.assertEqual(dBesselj(1, 0), 0.5)
 
     def test_Bessely(self):
         Bessely = polynomials.bessely
 
-        self.assertEqual(Bessely(1, 3), -Bessely(-1,3))
+        self.assertEqual(Bessely(1, 3), -Bessely(-1, 3))
         self.assertTrue(Bessely(1, 3) > 0)
-
 
     def test_dBessely(self):
         dBessely = polynomials.dbessely
 
-        self.assertEqual(dBessely(1, 3), -dBessely(-1,3))
+        self.assertEqual(dBessely(1, 3), -dBessely(-1, 3))
         self.assertTrue(dBessely(1, 3) > 0)
-
 
     def test_RicBesj(self):
         Ricbesj = polynomials.ricbesj
 
         self.assertEqual(Ricbesj(4, 0), 0)
-        self.assertTrue(abs(Ricbesj(1, 8)- 0.2691) < 1e-3)
-
+        self.assertTrue(abs(Ricbesj(1, 8) - 0.2691) < 1e-3)
 
     def test_dRicBesj(self):
         dRicBesj = polynomials.dricbesj
 
         self.assertTrue(abs(dRicBesj(1, 1) - 0.5403) < 1e-3)
 
-
     def test_RicBesy(self):
         RicBesy = polynomials.ricbesy
 
         self.assertTrue(abs(RicBesy(2, 3) - 0.8011) < 1e-3)
-
 
     def test_dRicBesy(self):
         dRicBesy = polynomials.dricbesy
 
         self.assertTrue(abs(dRicBesy(1, 1) + 0.8414) < 1e-3)
 
-
     def test_RicBesh(self):
         RicBesh = polynomials.ricbesh
 
         self.assertTrue(abs(RicBesh(3, 2) - (0.1214 - 2.968j)) < 1e-3)
 
-
     def test_dRicBesh(self):
         dRicBesh = polynomials.dricbesh
 
-        self.assertTrue(abs(dRicBesh(2, 6) - (-0.9321-0.2206j)) < 1e-3)
+        self.assertTrue(abs(dRicBesh(2, 6) - (-0.9321 - 0.2206j)) < 1e-3)

--- a/deeptrack/tests/test_aberrations.py
+++ b/deeptrack/tests/test_aberrations.py
@@ -5,11 +5,11 @@ import sys
 import unittest
 import numpy as np
 
-from .. import aberrations
+from deeptrack import aberrations
 
-from ..scatterers import PointParticle
-from ..optics import Fluorescence
-from ..image import Image
+from deeptrack.scatterers import PointParticle
+from deeptrack.optics import Fluorescence
+from deeptrack.image import Image
 
 
 

--- a/deeptrack/tests/test_elementwise.py
+++ b/deeptrack/tests/test_elementwise.py
@@ -9,7 +9,7 @@ from numpy.core.numeric import array_equal
 
 from numpy.testing._private.utils import assert_almost_equal
 
-from .. import elementwise, features, Image
+from deeptrack import elementwise, features, Image
 
 import numpy as np
 

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -8,52 +8,74 @@ import numpy as np
 from scipy.ndimage import uniform_filter
 
 from deeptrack import math
+from deeptrack.backend import config, xp
+from deeptrack.tests import BackendTestBase
 
 try:
     import cv2
+
     OPENCV_AVAILABLE = True
 except ImportError:
     OPENCV_AVAILABLE = False
 
-class TestMath(unittest.TestCase):
+
+class TestMathNumpy(BackendTestBase):
+    BACKEND = "numpy"
+
     def test_Average(self):
         expected_shape = (10, 30, 20)
-        input_image0 = np.ones((10, 30, 20)) * 2
-        input_image1 = np.ones((10, 30, 20)) * 4
+        input_image0 = xp.ones((10, 30, 20)) * 2
+        input_image1 = xp.ones((10, 30, 20)) * 4
         feature = math.Average(axis=0)
         average = feature.resolve([input_image0, input_image1])
-        self.assertTrue(np.all(average == 3), True)
+        self.assertTrue(xp.all(average == 3), True)
         self.assertEqual(average.shape, expected_shape)
 
     def test_Clip(self):
-        input_image = np.array([[10, 4], [4, -10]])
+        input_image = xp.asarray(np.array([[10, 4], [4, -10]]))
+        expected_output_1 = xp.asarray(np.array([[5, 4], [4, -5]]))
+        expected_output_2 = xp.asarray(np.array([[5, 6], [7, 8]]))
+
         feature = math.Clip(min=-5, max=5)
         clipped_feature = feature.resolve(input_image)
-        self.assertTrue(np.all(clipped_feature == [[5, 4], [4, -5]]))
+        self.assertTrue(xp.all(clipped_feature == expected_output_1))
 
-        input_image = np.array([[5, 6], [7, 8]])
+        input_image = xp.asarray(np.array([[5, 6], [7, 8]]))
         feature = math.Clip(min=0, max=10)
         clipped_feature = feature.resolve(input_image)
-        self.assertTrue(np.all(clipped_feature == [[5, 6], [7, 8]]))
+        self.assertTrue(xp.all(clipped_feature == expected_output_2))
 
     def test_NormalizeMinMax(self):
+        input_image = xp.asarray(np.array([[10, 4], [4, -10]]))
+        expected_output = xp.asarray(np.array([[5, 2], [2, -5]]))
+
         feature = math.NormalizeMinMax(min=-5, max=5)
-        input_image = np.array([[10, 4], [4, -10]])
         normalized_image = feature.resolve(input_image)
-        self.assertTrue(np.all(normalized_image == [[5, 2], [2, -5]]))
+        self.assertTrue(xp.all(normalized_image == expected_output))
 
     def test_NormalizeStandard(self):
         feature = math.NormalizeStandard()
-        input_image = np.array([[1, 2], [3, 4]], dtype=float)
+        input_image = xp.asarray(np.array([[1, 2], [3, 4]], dtype=float))
         normalized_image = feature.resolve(input_image)
-        self.assertEqual(np.mean(normalized_image), 0)
-        self.assertEqual(np.std(normalized_image), 1)
+        self.assertEqual(xp.mean(normalized_image), 0)
+        self.assertEqual(xp.std(normalized_image), 1)
 
     def test_Blur(self):
-        input_image = np.array([[1, 2], [3, 4]], dtype=float)
+        input_image = xp.asarray(np.array([[1, 2], [3, 4]], dtype=float))
+        expected_output = xp.asarray(np.array([[1, 1.5], [2, 2.5]]))
+
         feature = math.Blur(filter_function=uniform_filter, size=2)
         blurred_image = feature.resolve(input_image)
-        self.assertTrue(np.all(blurred_image == [[1, 1.5], [2, 2.5]]))
+        self.assertTrue(xp.all(blurred_image == expected_output))
+
+
+# Extending the test and setting the backend to torch
+class TestMathTorch(TestMathNumpy):
+    BACKEND = "torch"
+    pass
+
+
+class TestMath(unittest.TestCase):
 
     def test_GaussianBlur(self):
         input_image = np.array([[1, 2], [3, 4]], dtype=float)
@@ -64,16 +86,14 @@ class TestMath(unittest.TestCase):
         input_image = np.array([[1, 2], [3, 4]], dtype=float)
         feature = math.GaussianBlur(sigma=1000)
         blurred_image = feature.resolve(input_image)
-        self.assertTrue(
-            np.all(blurred_image - [[2.5, 2.5], [2.5, 2.5]] <= 0.01)
-        )
+        self.assertTrue(np.all(blurred_image - [[2.5, 2.5], [2.5, 2.5]] <= 0.01))
 
     def test_AveragePooling(self):
         input_image = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=float)
         feature = math.AveragePooling(ksize=2)
         pooled_image = feature.resolve(input_image)
         self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
-    
+
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         feature = math.MaxPooling(ksize=2)
@@ -114,38 +134,72 @@ class TestMath(unittest.TestCase):
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_BlurCV2_GaussianBlur(self):
         input_image = np.random.rand(32, 32).astype(np.float32)
-        expected_output = cv2.GaussianBlur(input_image, ksize=(5, 5), sigmaX=1, borderType=cv2.BORDER_REFLECT)
-        feature = math.BlurCV2(filter_function=cv2.GaussianBlur, ksize=(5, 5), sigmaX=1, mode='reflect')
+        expected_output = cv2.GaussianBlur(
+            input_image, ksize=(5, 5), sigmaX=1, borderType=cv2.BORDER_REFLECT
+        )
+        feature = math.BlurCV2(
+            filter_function=cv2.GaussianBlur, ksize=(5, 5), sigmaX=1, mode="reflect"
+        )
         output_image = feature.resolve(input_image)
         self.assertTrue(output_image.shape == expected_output.shape)
         self.assertIsNone(
             np.testing.assert_allclose(
-                output_image, expected_output, rtol=1e-5, atol=1e-6,
+                output_image,
+                expected_output,
+                rtol=1e-5,
+                atol=1e-6,
             )
         )
+
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_BlurCV2_bilateralFilter(self):
         input_image = np.random.rand(32, 32).astype(np.float32)
-        expected_output = cv2.bilateralFilter(input_image, d=9, sigmaColor=75, sigmaSpace=75, borderType=cv2.BORDER_REFLECT)
-        feature = math.BlurCV2(filter_function=cv2.bilateralFilter, d=9, sigmaColor=75, sigmaSpace=75, mode='reflect')
+        expected_output = cv2.bilateralFilter(
+            input_image,
+            d=9,
+            sigmaColor=75,
+            sigmaSpace=75,
+            borderType=cv2.BORDER_REFLECT,
+        )
+        feature = math.BlurCV2(
+            filter_function=cv2.bilateralFilter,
+            d=9,
+            sigmaColor=75,
+            sigmaSpace=75,
+            mode="reflect",
+        )
         output_image = feature.resolve(input_image)
         self.assertTrue(output_image.shape == expected_output.shape)
         self.assertIsNone(
             np.testing.assert_allclose(
-                output_image, expected_output, rtol=1e-5, atol=1e-6,
+                output_image,
+                expected_output,
+                rtol=1e-5,
+                atol=1e-6,
             )
         )
-    
+
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_BilateralBlur(self):
         input_image = np.random.rand(32, 32).astype(np.float32)
-        expected_output = cv2.bilateralFilter(input_image, d=9, sigmaColor=75, sigmaSpace=75, borderType=cv2.BORDER_REFLECT)
-        feature = math.BilateralBlur(d=9, sigma_color=75, sigma_space=75, mode='reflect')
+        expected_output = cv2.bilateralFilter(
+            input_image,
+            d=9,
+            sigmaColor=75,
+            sigmaSpace=75,
+            borderType=cv2.BORDER_REFLECT,
+        )
+        feature = math.BilateralBlur(
+            d=9, sigma_color=75, sigma_space=75, mode="reflect"
+        )
         output_image = feature.resolve(input_image)
         self.assertTrue(output_image.shape == expected_output.shape)
         self.assertIsNone(
             np.testing.assert_allclose(
-                output_image, expected_output, rtol=1e-5, atol=1e-6,
+                output_image,
+                expected_output,
+                rtol=1e-5,
+                atol=1e-6,
             )
         )
 

--- a/deeptrack/tests/test_optics.py
+++ b/deeptrack/tests/test_optics.py
@@ -6,10 +6,10 @@ import unittest
 
 from deeptrack import features
 from deeptrack import units as u
-from .. import optics
+from deeptrack import optics
 
-from ..scatterers import PointParticle, Sphere
-from ..image import Image
+from deeptrack.scatterers import PointParticle, Sphere
+from deeptrack.image import Image
 
 
 import numpy as np

--- a/deeptrack/tests/test_scatterers.py
+++ b/deeptrack/tests/test_scatterers.py
@@ -4,11 +4,11 @@ sys.path.append(".")  # Adds the module to path
 
 import unittest
 
-from .. import scatterers
+from deeptrack import scatterers
 
 import numpy as np
-from ..optics import Fluorescence, Brightfield
-from ..image import Image
+from deeptrack.optics import Fluorescence, Brightfield
+from deeptrack.image import Image
 
 
 class TestScatterers(unittest.TestCase):

--- a/deeptrack/tests/test_sequences.py
+++ b/deeptrack/tests/test_sequences.py
@@ -6,10 +6,10 @@ import unittest
 
 from matplotlib import pyplot
 
-from .. import sequences
+from deeptrack import sequences
 
-from ..optics import Fluorescence
-from ..scatterers import Ellipse
+from deeptrack.optics import Fluorescence
+from deeptrack.scatterers import Ellipse
 import numpy as np
 
 

--- a/deeptrack/tests/test_utils.py
+++ b/deeptrack/tests/test_utils.py
@@ -8,7 +8,7 @@
 
 import unittest
 
-from .. import utils
+from deeptrack import utils
 
 
 class TestUtils(unittest.TestCase):
@@ -19,14 +19,12 @@ class TestUtils(unittest.TestCase):
             utils.hasmethod(utils, "this_is_definetely_not_a_method_of_utils")
         )
 
-
     def test_as_list(self):
         obj = 1
         self.assertEqual(utils.as_list(obj), [obj])
 
         list_obj = [1, 2, 3]
         self.assertEqual(utils.as_list(list_obj), list_obj)
-
 
     def test_get_kwarg_names(self):
         def func1():
@@ -63,7 +61,6 @@ class TestUtils(unittest.TestCase):
             pass
 
         self.assertEqual(utils.get_kwarg_names(func7), ["key1", "key2", "key3"])
-
 
     def test_safe_call(self):
 

--- a/deeptrack/types.py
+++ b/deeptrack/types.py
@@ -50,11 +50,10 @@ from typing import Callable, List, Tuple, TypeVar, Union, TYPE_CHECKING
 
 import numpy as np
 
-from deeptrack.image import Image
 
 if TYPE_CHECKING:
     import torch
-
+    from deeptrack.image import Image
 
 # T is a generic type variable defining generic types for reusability.
 _T = TypeVar("T")
@@ -65,7 +64,7 @@ PropertyLike = Union[_T, Callable[..., _T]]
 
 # ArrayLike is a type alias representing any array-like structure.
 # It supports tuples, lists, and numpy arrays containing elements of type T.
-ArrayLike = Union[np.ndarray, "torch.Tensor", Image, List[_T], Tuple[_T, ...]]
+ArrayLike = Union[np.ndarray, "torch.Tensor", "Image", List[_T], Tuple[_T, ...]]
 
 # NumberLike is a type alias representing any numeric type including arrays.
 NumberLike = Union[np.ndarray, "torch.Tensor", int, float, bool, complex]

--- a/deeptrack/types.py
+++ b/deeptrack/types.py
@@ -1,9 +1,9 @@
 """Type declarations for internal use.
 
-This module defines type aliases and utility types to standardize the type 
-annotations used throughout the codebase. It enhances code readability, 
-maintainability, and reduces redundancy in type annotations. These types are 
-particularly useful for properties and array-like structures used within the 
+This module defines type aliases and utility types to standardize the type
+annotations used throughout the codebase. It enhances code readability,
+maintainability, and reduces redundancy in type annotations. These types are
+particularly useful for properties and array-like structures used within the
 library.
 
 Defined Types
@@ -13,7 +13,7 @@ Defined Types
 - `ArrayLike`
     A type alias for array-like structures (e.g., tuples, lists, numpy arrays).
 - `NumberLike`
-    A type alias for numeric types, including scalars and arrays (e.g., numpy 
+    A type alias for numeric types, including scalars and arrays (e.g., numpy
     arrays, GPU tensors).
 
 Examples
@@ -45,40 +45,27 @@ Using `NumberLike`:
 
 """
 
-from typing import Callable, List, Tuple, TypeVar, Union
+from __future__ import annotations
+from typing import Callable, List, Tuple, TypeVar, Union, TYPE_CHECKING
 
 import numpy as np
 
-# Try importing optional libraries for GPU arrays and tensors.
-try:
-    import cupy
-    _CUPY_AVAILABLE = True
-except ImportError:
-    _CUPY_AVAILABLE = False
+from deeptrack.image import Image
 
-try:
+if TYPE_CHECKING:
     import torch
-    _TORCH_AVAILABLE = True
-except ImportError:
-    _TORCH_AVAILABLE = False
 
 
 # T is a generic type variable defining generic types for reusability.
 _T = TypeVar("T")
 
-# PropertyLike is a type alias representing a value of type T 
+# PropertyLike is a type alias representing a value of type T
 # or a callable returning type T.
 PropertyLike = Union[_T, Callable[..., _T]]
 
 # ArrayLike is a type alias representing any array-like structure.
 # It supports tuples, lists, and numpy arrays containing elements of type T.
-ArrayLike = Union[Tuple[_T, ...], List[_T], np.ndarray]
+ArrayLike = Union[np.ndarray, "torch.Tensor", Image, List[_T], Tuple[_T, ...]]
 
 # NumberLike is a type alias representing any numeric type including arrays.
-NumberLike = Union[np.ndarray, int, float, bool, complex]
-
-if _CUPY_AVAILABLE:
-    NumberLike = Union[NumberLike, cupy.ndarray]
-
-if _TORCH_AVAILABLE:
-    NumberLike = Union[NumberLike, torch.Tensor]
+NumberLike = Union[np.ndarray, "torch.Tensor", int, float, bool, complex]


### PR DESCRIPTION
This is a test implementation of a few classes in deeptrack.math. It's to demonstrate how I envision the implementation working.

Note:
array creation should always set dtype and device:
xp.zeros((100, 100), dtype=self.float_dtype, device=self.device)

torch does not automatically create arrays from lists. so we should systematically use stack instead (same functionality for lists of arrays). 

I also show how unittests can work. We just need to set BACKEND=... to run the tests again with torch backend. 
