### PR TITLE
DTAT306: Added SequentialProperty Example.

### DIFF
--- a/tutorials/3-advanced-topics/DTAT306_properties.ipynb
+++ b/tutorials/3-advanced-topics/DTAT306_properties.ipynb
@@ -468,6 +468,94 @@
         "    property_dict.update()\n",
         "    print(f\"The current properties in property_dict are {property_dict()}\")"
       ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## 4. What is a SequentialProperty?\n",
+        "`SequentialProperty` is a class that extends `Property` with iterative utilities, and lets the user encapsulate features and iterator logic in a single object with functions such as:\n",
+        "* `set_sequence_length()`, which specifies the sequence length.\n",
+        "* `set_current_step()`, which specifies the current index in the sequence.\n",
+        "\n",
+        "Start by defining a `SequentialProperty` with a length and a sampling rule."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Set the SequentialProperty update rule to be random sampling.\n",
+        "seq_prop = SequentialProperty(current_value=np.random.rand)\n",
+        "\n",
+        "# Specify length of sequence.\n",
+        "seq_prop.set_sequence_length(5)\n",
+        "print(seq_prop.sequence_length())\n",
+        "\n",
+        "# Evaluate update rule.\n",
+        "print(seq_prop.current())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4.1 Evaluate the sequence\n",
+        "We now iterate with the `SequentialProperty` with its update rule and sequence length to obtain new values at each step."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "for index in range(seq_prop.sequence_length()):\n",
+        "\n",
+        "    # Set the current index of the sequence.\n",
+        "    seq_prop.set_current_step(index)\n",
+        "\n",
+        "    # Evaluate feature\n",
+        "    current_value = seq_prop.current()\n",
+        "\n",
+        "    # Store \n",
+        "    seq_prop.store(current_value)\n",
+        "\n",
+        "# Print all the stored values.\n",
+        "print(seq_prop.data[()].current_value())"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### 4.2 A Different Sampling Rule"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Set the sampling rule to be the index of the sequence, and sum.\n",
+        "seq_prop.current = lambda _ID=(): seq_prop.sequence_step() + 1\n",
+        "\n",
+        "for index in range(seq_prop.sequence_length()):\n",
+        "\n",
+        "    seq_prop.set_current_step(index)\n",
+        "\n",
+        "    # Evaluate sampling rule.\n",
+        "    current_value = seq_prop.current()\n",
+        "\n",
+        "    # Store \n",
+        "    seq_prop.store(current_value)\n",
+        "\n",
+        "    # Print the value in each iteration.\n",
+        "    print(seq_prop.data[()].current_value())"
+      ]
     }
   ],
   "metadata": {

--- a/tutorials/3-advanced-topics/DTAT306_properties.ipynb
+++ b/tutorials/3-advanced-topics/DTAT306_properties.ipynb
@@ -540,21 +540,22 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "# Set the sampling rule to be the index of the sequence, and sum.\n",
-        "seq_prop.current = lambda _ID=(): seq_prop.sequence_step() + 1\n",
+        "seq_prop = SequentialProperty(current_value=lambda _ID=(): seq_prop.sequence_step() + 1)\n",
+        "seq_prop.set_sequence_length(5)\n",
         "\n",
         "for index in range(seq_prop.sequence_length()):\n",
         "\n",
         "    seq_prop.set_current_step(index)\n",
         "\n",
-        "    # Evaluate sampling rule.\n",
+        "    # Evaluate update rule\n",
         "    current_value = seq_prop.current()\n",
         "\n",
         "    # Store \n",
         "    seq_prop.store(current_value)\n",
         "\n",
-        "    # Print the value in each iteration.\n",
-        "    print(seq_prop.data[()].current_value())"
+        "\n",
+        "# Print all the stored values.\n",
+        "print(seq_prop.data[()].current_value())"
       ]
     }
   ],


### PR DESCRIPTION
This small PR adds an example of how to use SequentialProperty without `Feature` and `store()` in the DTAT306_properties tutorial.