### PR TITLE
Add feature method "get_backend" + unittesting

### DIFF
--- a/deeptrack/features.py
+++ b/deeptrack/features.py
@@ -333,6 +333,8 @@ class Feature(DeepTrackNode):
         It sets the backend to torch.
     `numpy(recursice: bool) -> Feature`
         It set the backend to numpy.
+    `get_backend() -> Literal["numpy", "torch"]`
+        It returns the current backend of the feature.
     `dtype(float: Literal["float32", "float64", "default"] or None, int: Literal["int16", "int32", "int64", "default"] or None, complex: Literal["complex64", "complex128", "default"] or None, bool: Literal["bool", "default"] or None) -> Feature`
         It set the dtype to be used during evaluation.
     `to(device: str or torch.device) -> Feature`
@@ -872,6 +874,31 @@ class Feature(DeepTrackNode):
                     dependency.numpy(recursive=False)
         self.invalidate()
         return self
+    
+    def get_backend(
+            self: Feature
+    ) -> Literal["numpy", "torch"]:
+        """Get the current backend of the feature.
+
+        Returns
+        -------
+        Literal["numpy", "torch"]
+            The backend of this feature
+
+        Examples
+        --------
+        >>> import deeptrack as dt
+        >>> feature = dt.Add(value=5)
+        >>> feature.numpy()
+        >>> feature.get_backend()
+        'numpy'
+
+        >>> feature.torch()
+        >>> feature.get_backend()
+        'torch'
+
+        """
+        return self._backend
 
     def dtype(
         self: Feature,

--- a/deeptrack/tests/test_features.py
+++ b/deeptrack/tests/test_features.py
@@ -131,6 +131,16 @@ def test_operator(self, operator, emulated_operator=None):
         operator,
     )
 
+def test_backend_switching(self):
+    f = features.Add(value=5)
+
+    f.numpy()
+    self.assertEqual(f.get_backend(), "numpy")
+
+    if TORCH_AVAILABLE:
+        f.torch()
+        self.assertEqual(f.get_backend(), "torch")
+
 
 class TestFeatures(unittest.TestCase):
 


### PR DESCRIPTION
Added the method "get_backend" to Features, which returns the current backend of the feature.

Added a simple unit test that switches the backend of the feature between NumPy and PyTorch and verifies the change using "get_backend".