### PR TITLE
fix CI unittests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ description = "A deep learning framework to enhance microscopy, developed by Dee
 readme = "README.md"
 requires-python = ">=3.9"
 
+[tool.pytest.ini_options]
+minversion = "6.0"
+testpaths = [
+    "deeptrack/benchmarks",
+]
+
 [[tool.uv.index]]
 name = "pytorch-cu126"
 url = "https://download.pytorch.org/whl/cu126"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,3 @@
-[project]
-name = "deeptrack"
-version = "2.0.1"
-description = "A deep learning framework to enhance microscopy, developed by DeepTrackAI."
-readme = "README.md"
-requires-python = ">=3.9"
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ version = "2.0.1"
 description = "A deep learning framework to enhance microscopy, developed by DeepTrackAI."
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = []
 
 [[tool.uv.index]]
 name = "pytorch-cu126"


### PR DESCRIPTION
Previously merged pyproject.toml seems to have affected how unittests are run in GitHub Actions (but not locally). This PR fixes this issue