### PR TITLE
Math/AveragePooling

### DIFF
--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1156,14 +1156,14 @@ class Pool(Feature):
         image: NDArray | torch.Tensor | Image,
         ksize: int,
         **kwargs: Any,
-    ) -> np.ndarray | torch.Tensor:
+    ) -> NDArray | torch.Tensor:
         """Applies the pooling function to the input image.
 
         This method applies `pooling_function` to the input image.
 
         Parameters
         ----------
-        image: np.ndarray | torch.Tensor | Image
+        image: NDArray | torch.Tensor | Image
             The input image to pool.
         ksize: int
             Size of the pooling kernel.
@@ -1172,7 +1172,7 @@ class Pool(Feature):
 
         Returns
         -------
-        np.ndarray | torch.Tensor
+        NDArray | torch.Tensor
             The pooled image.
 
         """

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1191,46 +1191,38 @@ class Pool(Feature): # Deprecated, children will be independent in the future.
 class AveragePooling(Pool):
     """Apply average pooling to an image.
 
-    This class inherits from `Pool` to reduce the resolution of an image by
-    dividing it into non-overlapping blocks of size `ksize` and applying the
-    `max` function to each block. The result is a downsampled image where each
-    pixel value represents the maximum value within the corresponding block of
-    the original image. This is useful for reducing the size of an image while
+    `AveragePooling` reduces the resolution of an image by dividing it into
+    non-overlapping blocks of size `ksize` and applying the `average` function
+    to each block. The result is a downsampled image where each pixel value
+    represents the average value within the corresponding block of the
+    original image. This is useful for reducing the size of an image while
     retaining the most significant features.
 
-    If the backend is numpy, the downsampling is performed using
+    If the backend is NumPy, the downsampling is performed using
     `skimage.measure.block_reduce`.
-    If the backend is torch, the downsampling
+    If the backend is PyTorch, the downsampling
     is performed using `torch.nn.functional.avg_pool2d`.
 
     Parameters
     ----------
     ksize: int
         Size of the pooling kernel.
-    **kwargs: dict
+    **kwargs: any
         Additional parameters sent to the pooling function.
 
     Examples
     --------
     >>> import deeptrack as dt
-    >>> import numpy as np
-
     Create an input image:
+    >>> import numpy as np
+    >>>
     >>> input_image = np.random.rand(32, 32)
 
-    Define an average pooling feature:
+    Define and use a average pooling feature:
     >>> average_pooling = dt.AveragePooling(ksize=4)
     >>> output_image = average_pooling(input_image)
     >>> print(output_image.shape)
     (8, 8)
-
-    Notes
-    -----
-    Calling this feature returns a pooled image of the input, it will return
-    either numpy or torch depending on the backend. If `store_properties` is
-    set to `True` and the input is a numpy array, the returned array will be
-    automatically wrapped in an `Image` object. This behavior is handled
-    internally and does not affect the return type of the `get()` method.
 
     """
 
@@ -1241,9 +1233,7 @@ class AveragePooling(Pool):
     ):
         """Initialize the parameters for average pooling.
 
-        This constructor initializes the parameters for average pooling and
-        checks whether to use the numpy or torch implementation, defaults to
-        numpy.
+        This constructor initializes the parameters for average pooling.
 
         Parameters
         ----------
@@ -1255,14 +1245,47 @@ class AveragePooling(Pool):
         """
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
+        
+        
+    def get(
+        self: AveragePooling,
+        image: NDArray[Any] | torch.Tensor,
+        ksize: int=3,
+        **kwargs: Any,
+    ) -> NDArray[Any] | torch.Tensor:
+        """Average pooling of input.
+        
+        Checks the current backend and chooses the appropriate function to pool
+        the input image, either `._get_torch()` or `._get_numpy()`.
+
+        Parameters
+        ----------
+        image: array or tensor
+            Input array or tensor to be pooled.
+        ksize: int
+            Kernel size of the pooling operation.
+
+        Returns
+        -------
+        array or tensor
+            The pooled input as `NDArray` or `torch.Tensor` depending on
+            the backend.
+
+        """
+        if self.get_backend() == "numpy":
+            return self._get_numpy(image, ksize, **kwargs)
+        elif self.get_backend() == "torch":
+            return self._get_torch(image, ksize, **kwargs)
+        else:
+            raise NotImplementedError(f"Backend {self.backend} not supported")
 
     def _get_numpy(
-        self,
-        image: NDArray,
+        self: AveragePooling,
+        image: NDArray[Any],
         ksize: int = 3,
-        **kwargs,
-    ):
-        """Method to perform average pooling with the numpy backend enabled.
+        **kwargs: Any,
+    ) -> NDArray[Any]:
+        """Average pooling with the NumPy backend enabled.
 
         Returns the result of the image passed to the scikit image block_reduce
         function with `np.mean()` as the pooling function.
@@ -1270,7 +1293,7 @@ class AveragePooling(Pool):
         Parameters
         ----------
         image: NDArray
-            Input image to be pooled.
+            Input array to be pooled.
         ksize: int
             Kernel size of the pooling operation.
 
@@ -1283,26 +1306,26 @@ class AveragePooling(Pool):
         return utils.safe_call(
             skimage.measure.block_reduce,
             image=image,
-            func=self.pooling, # This will be np.mean for this class.
+            func=np.average,
             block_size=ksize,
             **kwargs,
         )
 
     def _get_torch(
-        self,
+        self: AveragePooling,
         image: torch.Tensor,
         ksize: int=3,
-        **kwargs,
-    ):
-        """Method to perform average pooling with the torch backend enabled.
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        """Perform average pooling with the PyTorch backend enabled.
         
-        Returns the result of the image passed to a torch average
+        Returns the result of the image passed to a Pytorch average
         pooling layer.
 
         Parameters
         ----------
         image: torch.Tensor
-            Input image to be pooled.
+            Input tensor to be pooled.
         ksize: int
             Kernel size of the pooling operation.
 
@@ -1313,8 +1336,9 @@ class AveragePooling(Pool):
 
         """
 
-        # If needed, expand tensor shape
+        # If input tensor is 2D
         if len(image.shape) == 2:
+            # Add batch dimension for max pooling.
             expanded_image = image.unsqueeze(0)
 
             pooled_image = torch.nn.functional.avg_pool2d(
@@ -1327,38 +1351,6 @@ class AveragePooling(Pool):
             image,
             kernel_size=ksize,
         )
-
-    def get(
-        self,
-        image: NDArray | torch.Tensor,
-        ksize: int=3,
-        **kwargs,
-    ):
-        """Method to perform pooling with either torch or numpy backend.
-        
-        Checks the current backend and chooses the appropriate function to pool
-        the input image, either `_get_torch` or `_get_numpy`.
-
-        Parameters
-        ----------
-        image: NDArray | torch.Tensor
-            Input image to be pooled.
-        ksize: int
-            Kernel size of the pooling operation.
-
-        Returns
-        -------
-        NDArray | torch.Tensor
-            The pooled image as `NDArray` or `torch.Tensor` depending on
-            the backend.
-
-        """
-        if self.get_backend() == "numpy":
-            return self._get_numpy(image, ksize, **kwargs,)
-        elif self.get_backend() == "torch":
-            return self._get_torch(image, ksize, **kwargs,)
-        else:
-            raise NotImplementedError(f"Backend {self.backend} not supported")
 
 
 #TODO ***AL*** revise MaxPooling - torch, typing, docstring, unit test

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1069,7 +1069,6 @@ class MedianBlur(Blur):
         super().__init__(ndimage.median_filter, size=ksize, **kwargs)
 
 
-#TODO ***AL*** revise Pool - torch, typing, docstring, unit test
 class Pool(Feature):
     """Downsamples the image by applying a function to local regions of the
     image.
@@ -1189,7 +1188,6 @@ class Pool(Feature):
         )
 
 
-#TODO ***AL*** revise AveragePooling - torch, typing, docstring, unit test
 class AveragePooling(Pool):
     # Check if numpy, call super, else use torch.AveragePooling2D
     """Apply average pooling to an image.
@@ -1255,7 +1253,7 @@ class AveragePooling(Pool):
         super().__init__(np.mean, ksize=ksize, **kwargs)
 
         def get(self, image, ksize: int, **kwargs):
-            
+
             # Check torch backend and if the type name starts with "torch".
             # Isinstance will not work when torch is not available.
             if TORCH_AVAILABLE and type(image).__module__.startswith("torch"):

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1085,8 +1085,8 @@ class Pool(Feature):
     pooling_function: function
         A function that is applied to each local region of the image.
         DOES NOT NEED TO BE WRAPPED IN ANOTHER FUNCTION.
-        The `pooling_function` must accept the input image as a keyword argument
-        named `input`, as it is called via `utils.safe_call`.
+        The `pooling_function` must accept the input image as a keyword
+        argument named `input`, as it is called via `utils.safe_call`.
         Examples include `np.mean`, `np.max`, `np.min`, etc.
     ksize: int
         Size of the pooling kernel.
@@ -1095,7 +1095,8 @@ class Pool(Feature):
 
     Methods
     -------
-    `get(image: np.ndarray | Image, ksize: int, **kwargs: Any) --> np.ndarray`
+    `get(image: NDArray | torch.Tensor | Image,
+         ksize: int, **kwargs: Any) --> NDArray | torch.Tensor`
         Applies the pooling function to the input image.
 
     Examples
@@ -1152,7 +1153,7 @@ class Pool(Feature):
 
     def get(
         self: Pool,
-        image: np.ndarray | Image,
+        image: NDArray | torch.Tensor | Image,
         ksize: int,
         **kwargs: Any,
     ) -> np.ndarray:
@@ -1162,7 +1163,7 @@ class Pool(Feature):
 
         Parameters
         ----------
-        image: np.ndarray
+        image: np.ndarray | torch.Tensor | Image
             The input image to pool.
         ksize: int
             Size of the pooling kernel.
@@ -1171,7 +1172,7 @@ class Pool(Feature):
 
         Returns
         -------
-        np.ndarray
+        np.ndarray | torch.Tensor
             The pooled image.
 
         """

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1156,10 +1156,10 @@ class Pool(Feature):
         image: NDArray | torch.Tensor | Image,
         ksize: int,
         **kwargs: Any,
-    ) -> np.ndarray:
+    ) -> np.ndarray | torch.Tensor:
         """Applies the pooling function to the input image.
 
-        This method applies the pooling function to the input image.
+        This method applies `pooling_function` to the input image.
 
         Parameters
         ----------

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1254,13 +1254,26 @@ class AveragePooling(Pool):
     def _get_numpy(
         self,
         image: NDArray,
-        ksize: int=3,
+        ksize: int = 3,
+        **kwargs,
     ):
         """Method to perform average pooling with the numpy backend enabled.
 
         Returns the result of the image passed to the scikit image block_reduce
         function with `np.mean()` as the pooling function.
-        
+
+        Parameters
+        ----------
+        image: NDArray
+            Input image to be pooled.
+        ksize: int
+            Kernel size of the pooling operation.
+
+        Returns
+        -------
+        NDArray
+            The pooled image as a `NDArray`.
+            
         """
         return utils.safe_call(
             skimage.measure.block_reduce,
@@ -1274,25 +1287,62 @@ class AveragePooling(Pool):
         self,
         image: torch.Tensor,
         ksize: int=3,
+        **kwargs,
     ):
         """Method to perform average pooling with the torch backend enabled.
         
-        Returns the result of the image passed to a torch average pooling layer.   
+        Returns the result of the image passed to a torch average
+        pooling layer.
+
+        Parameters
+        ----------
+        image: torch.Tensor
+            Input image to be pooled.
+        ksize: int
+            Kernel size of the pooling operation.
+
+        Returns
+        -------
+        torch.Tensor
+            The pooled image as a `torch.Tensor`.
 
         """
 
-        return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
+        return torch.nn.functional.avg_pool2d(
+            image,
+            kernel_size=ksize, 
+            **kwargs,
+        )
 
-     def get(
+    def get(
         self,
-        image: torch.Tensor | NDArray,
+        image: NDArray | torch.Tensor,
         ksize: int=3,
-        **kwargs
+        **kwargs,
     ):
+        """Method to perform pooling with either torch or numpy backend.
+        
+        Checks the current backend and chooses the appropriate function to pool
+        the input image, either `_get_torch` or `_get_numpy`.
+
+        Parameters
+        ----------
+        image: NDArray | torch.Tensor
+            Input image to be pooled.
+        ksize: int
+            Kernel size of the pooling operation.
+
+        Returns
+        -------
+        NDArray | torch.Tensor
+            The pooled image as `NDArray` or `torch.Tensor` depending on
+            the backend.
+
+        """
         if self.backend == "numpy":
-            return self._get_numpy(image, ksize, **kwargs)
+            return self._get_numpy(image, ksize, **kwargs,)
         elif self.backend == "torch":
-            return self._get_torch(image, ksize, **kwargs)
+            return self._get_torch(image, ksize, **kwargs,)
         else:
             raise NotImplementedError(f"Backend {self.backend} not supported")
 

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1189,7 +1189,6 @@ class Pool(Feature):
 
 
 class AveragePooling(Pool):
-    # Check if numpy, call super, else use torch.AveragePooling2D
     """Apply average pooling to an image.
 
     This class inherits from `Pool` to reduce the resolution of an image by
@@ -1252,7 +1251,12 @@ class AveragePooling(Pool):
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
 
-    def get(self, image, ksize: int, **kwargs):
+    def get(
+        self,
+        image,
+        ksize: int,
+        **kwargs
+    ):
         # Check torch backend and if the type name starts with "torch".
         # Isinstance will not work when torch is not available.
         if TORCH_AVAILABLE:

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1339,9 +1339,9 @@ class AveragePooling(Pool):
             the backend.
 
         """
-        if self.backend == "numpy":
+        if self.get_backend() == "numpy":
             return self._get_numpy(image, ksize, **kwargs,)
-        elif self.backend == "torch":
+        elif self.get_backend() == "torch":
             return self._get_torch(image, ksize, **kwargs,)
         else:
             raise NotImplementedError(f"Backend {self.backend} not supported")

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1069,7 +1069,7 @@ class MedianBlur(Blur):
         super().__init__(ndimage.median_filter, size=ksize, **kwargs)
 
 
-class Pool(Feature):
+class Pool(Feature): # Deprecated, children will be independent in the future.
     """Downsamples the image by applying a function to local regions of the
     image.
 
@@ -1251,18 +1251,50 @@ class AveragePooling(Pool):
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
 
-    def get(
+    def _get_numpy(
         self,
-        image,
-        ksize: int,
+        image: NDArray,
+        ksize: int=3,
+    ):
+        """Method to perform average pooling with the numpy backend enabled.
+
+        Returns the result of the image passed to the scikit image block_reduce
+        function with `np.mean()` as the pooling function.
+        
+        """
+        return utils.safe_call(
+            skimage.measure.block_reduce,
+            image=image,
+            func=self.pooling, # This will be np.mean for this class.
+            block_size=ksize,
+            **kwargs,
+        )
+
+    def _get_torch(
+        self,
+        image: torch.Tensor,
+        ksize: int=3,
+    ):
+        """Method to perform average pooling with the torch backend enabled.
+        
+        Returns the result of the image passed to a torch average pooling layer.   
+
+        """
+
+        return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
+
+     def get(
+        self,
+        image: torch.Tensor | NDArray,
+        ksize: int=3,
         **kwargs
     ):
-        # Check torch backend and if the type name starts with "torch".
-        # Isinstance will not work when torch is not available.
-        if TORCH_AVAILABLE:
-            if type(image).__module__.startswith("torch"):
-                return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
-        return super().get(image, ksize=ksize, **kwargs)
+        if self.backend == "numpy":
+            return self._get_numpy(image, ksize, **kwargs)
+        elif self.backend == "torch":
+            return self._get_torch(image, ksize, **kwargs)
+        else:
+            raise NotImplementedError(f"Backend {self.backend} not supported")
 
 
 #TODO ***AL*** revise MaxPooling - torch, typing, docstring, unit test

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1256,8 +1256,9 @@ class AveragePooling(Pool):
 
             # Check torch backend and if the type name starts with "torch".
             # Isinstance will not work when torch is not available.
-            if TORCH_AVAILABLE and type(image).__module__.startswith("torch"):
-                return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
+            if TORCH_AVAILABLE:
+                if type(image).__module__.startswith("torch"):
+                    return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
             return super().get(image, ksize=ksize, **kwargs)
 
 

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1252,14 +1252,13 @@ class AveragePooling(Pool):
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
 
-        def get(self, image, ksize: int, **kwargs):
-
-            # Check torch backend and if the type name starts with "torch".
-            # Isinstance will not work when torch is not available.
-            if TORCH_AVAILABLE:
-                if type(image).__module__.startswith("torch"):
-                    return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
-            return super().get(image, ksize=ksize, **kwargs)
+    def get(self, image, ksize: int, **kwargs):
+        # Check torch backend and if the type name starts with "torch".
+        # Isinstance will not work when torch is not available.
+        if TORCH_AVAILABLE:
+            if type(image).__module__.startswith("torch"):
+                return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
+        return super().get(image, ksize=ksize, **kwargs)
 
 
 #TODO ***AL*** revise MaxPooling - torch, typing, docstring, unit test

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1176,17 +1176,35 @@ class Pool(Feature):
             The pooled image.
 
         """
+        image_is_torch = isinstance(image, torch.Tensor)
+
+        # Convert to numpy to use skimage.measure.block_reduce.
+        if image_is_torch:
+            device = image.device
+            dtype = image.dtype
+            image = image.detach().cpu().numpy()
 
         kwargs.pop("func", False)
         kwargs.pop("image", False)
         kwargs.pop("block_size", False)
-        return utils.safe_call(
+
+        pooled_image = utils.safe_call(
             skimage.measure.block_reduce,
             image=image,
             func=self.pooling,
             block_size=ksize,
             **kwargs,
         )
+
+        # Convert back to torch.Tensor if needed.
+        if image_is_torch:
+            return torch.tensor(
+                pooled_image,
+                dtype=dtype,
+                device=device
+            )
+        
+        return pooled_image
 
 
 #TODO ***AL*** revise AveragePooling - torch, typing, docstring, unit test

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1310,8 +1310,7 @@ class AveragePooling(Pool):
 
         return torch.nn.functional.avg_pool2d(
             image,
-            kernel_size=ksize, 
-            **kwargs,
+            kernel_size=ksize,
         )
 
     def get(

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1195,8 +1195,8 @@ class AveragePooling(Pool):
     dividing it into non-overlapping blocks of size `ksize` and applying the
     average function to each block. The result is a downsampled image where
     each pixel value represents the average value within the corresponding
-    block of the original image. If TORCH_AVAILABLE, it will return the output
-    of `torch.nn.functional.avg_pool2d` instead.
+    block of the original image. If the backend is torch, it will return the
+    output of `torch.nn.functional.avg_pool2d` instead.
 
     Parameters
     ----------
@@ -1222,7 +1222,7 @@ class AveragePooling(Pool):
     Notes
     -----
     Calling this feature returns a pooled image of the input, it will return
-    either numpy or torch depending on the `TORCH_AVAILABLE` flag. If
+    either numpy or torch depending on the backend. If
     `store_properties` is set to `True` and the input is a numpy array,
     the returned array will be automatically wrapped in an `Image` object.
     This behavior is handled internally and does not affect the return type

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1238,7 +1238,8 @@ class AveragePooling(Pool):
         """Initialize the parameters for average pooling.
 
         This constructor initializes the parameters for average pooling and
-        checks whether to use the numpy or torch implementation.
+        checks whether to use the numpy or torch implementation, defaults to
+        numpy.
 
         Parameters
         ----------

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1193,10 +1193,15 @@ class AveragePooling(Pool):
 
     This class inherits from `Pool` to reduce the resolution of an image by
     dividing it into non-overlapping blocks of size `ksize` and applying the
-    average function to each block. The result is a downsampled image where
-    each pixel value represents the average value within the corresponding
-    block of the original image. If the backend is torch, it will return the
-    output of `torch.nn.functional.avg_pool2d` instead.
+    `max` function to each block. The result is a downsampled image where each
+    pixel value represents the maximum value within the corresponding block of
+    the original image. This is useful for reducing the size of an image while
+    retaining the most significant features.
+
+    If the backend is numpy, the downsampling is performed using
+    `skimage.measure.block_reduce`.
+    If the backend is torch, the downsampling
+    is performed using `torch.nn.functional.avg_pool2d`.
 
     Parameters
     ----------
@@ -1222,11 +1227,10 @@ class AveragePooling(Pool):
     Notes
     -----
     Calling this feature returns a pooled image of the input, it will return
-    either numpy or torch depending on the backend. If
-    `store_properties` is set to `True` and the input is a numpy array,
-    the returned array will be automatically wrapped in an `Image` object.
-    This behavior is handled internally and does not affect the return type
-    of the `get()` method.
+    either numpy or torch depending on the backend. If `store_properties` is
+    set to `True` and the input is a numpy array, the returned array will be
+    automatically wrapped in an `Image` object. This behavior is handled
+    internally and does not affect the return type of the `get()` method.
 
     """
 
@@ -1308,6 +1312,16 @@ class AveragePooling(Pool):
             The pooled image as a `torch.Tensor`.
 
         """
+
+        # If needed, expand tensor shape
+        if len(image.shape) == 2:
+            expanded_image = image.unsqueeze(0)
+
+            pooled_image = torch.nn.functional.avg_pool2d(
+                expanded_image, kernel_size=ksize,
+            )
+            # Remove the expanded dim.
+            return pooled_image.squeeze(0)
 
         return torch.nn.functional.avg_pool2d(
             image,

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1207,18 +1207,20 @@ class AveragePooling(Pool):
     ----------
     ksize: int
         Size of the pooling kernel.
-    **kwargs: any
+    **kwargs: Any
         Additional parameters sent to the pooling function.
 
     Examples
     --------
     >>> import deeptrack as dt
+
     Create an input image:
     >>> import numpy as np
     >>>
     >>> input_image = np.random.rand(32, 32)
 
-    Define and use a average pooling feature:
+    Define and use a average-pooling feature:
+
     >>> average_pooling = dt.AveragePooling(ksize=4)
     >>> output_image = average_pooling(input_image)
     >>> print(output_image.shape)
@@ -1227,13 +1229,13 @@ class AveragePooling(Pool):
     """
 
     def __init__(
-        self: Pool,
+        self: AveragePooling,
         ksize: PropertyLike[int] = 3,
         **kwargs: Any,
     ):
         """Initialize the parameters for average pooling.
 
-        This constructor initializes the parameters for average pooling.
+        This constructor initializes the parameters for average-pooling.
 
         Parameters
         ----------
@@ -1245,8 +1247,7 @@ class AveragePooling(Pool):
         """
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
-        
-        
+
     def get(
         self: AveragePooling,
         image: NDArray[Any] | torch.Tensor,
@@ -1254,7 +1255,7 @@ class AveragePooling(Pool):
         **kwargs: Any,
     ) -> NDArray[Any] | torch.Tensor:
         """Average pooling of input.
-        
+
         Checks the current backend and chooses the appropriate function to pool
         the input image, either `._get_torch()` or `._get_numpy()`.
 
@@ -1272,12 +1273,14 @@ class AveragePooling(Pool):
             the backend.
 
         """
+
         if self.get_backend() == "numpy":
             return self._get_numpy(image, ksize, **kwargs)
-        elif self.get_backend() == "torch":
+
+        if self.get_backend() == "torch":
             return self._get_torch(image, ksize, **kwargs)
-        else:
-            raise NotImplementedError(f"Backend {self.backend} not supported")
+
+        raise NotImplementedError(f"Backend {self.backend} not supported")
 
     def _get_numpy(
         self: AveragePooling,
@@ -1287,8 +1290,8 @@ class AveragePooling(Pool):
     ) -> NDArray[Any]:
         """Average pooling with the NumPy backend enabled.
 
-        Returns the result of the image passed to the scikit image block_reduce
-        function with `np.mean()` as the pooling function.
+        Returns the result of the image passed to the scikit image
+        `block_reduce()` function with `np.mean()` as the pooling function.
 
         Parameters
         ----------
@@ -1299,10 +1302,11 @@ class AveragePooling(Pool):
 
         Returns
         -------
-        NDArray
-            The pooled image as a `NDArray`.
-            
+        array
+            The pooled image as a NumPy array.
+
         """
+
         return utils.safe_call(
             skimage.measure.block_reduce,
             image=image,
@@ -1317,10 +1321,10 @@ class AveragePooling(Pool):
         ksize: int=3,
         **kwargs: Any,
     ) -> torch.Tensor:
-        """Perform average pooling with the PyTorch backend enabled.
+        """Average pooling with the PyTorch backend enabled.
         
-        Returns the result of the image passed to a Pytorch average
-        pooling layer.
+        Returns the result of the image passed to a Pytorch average pooling
+        layer.
 
         Parameters
         ----------

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1078,11 +1078,11 @@ class Pool(Feature):
     non-overlapping blocks of size `ksize` and applying the specified pooling
     function to each block. The result is a downsampled image where each pixel
     value represents the result of the pooling function applied to the
-    corresponding block.
+    corresponding block. This pooling only works with numpy functions.  
 
     Parameters
     ----------
-    pooling_function: function
+    pooling_function:  Numpy function
         A function that is applied to each local region of the image.
         DOES NOT NEED TO BE WRAPPED IN ANOTHER FUNCTION.
         The `pooling_function` must accept the input image as a keyword
@@ -1095,8 +1095,8 @@ class Pool(Feature):
 
     Methods
     -------
-    `get(image: NDArray | torch.Tensor | Image,
-         ksize: int, **kwargs: Any) --> NDArray | torch.Tensor`
+    `get(image: NDArray,
+         ksize: int, **kwargs: Any) --> NDArray`
         Applies the pooling function to the input image.
 
     Examples
@@ -1153,17 +1153,17 @@ class Pool(Feature):
 
     def get(
         self: Pool,
-        image: NDArray | torch.Tensor | Image,
+        image: NDArray,
         ksize: int,
         **kwargs: Any,
-    ) -> NDArray | torch.Tensor:
+    ) -> NDArray:
         """Applies the pooling function to the input image.
 
         This method applies `pooling_function` to the input image.
 
         Parameters
         ----------
-        image: NDArray | torch.Tensor | Image
+        image: NDArray | torch.Tensor
             The input image to pool.
         ksize: int
             Size of the pooling kernel.
@@ -1176,19 +1176,11 @@ class Pool(Feature):
             The pooled image.
 
         """
-        image_is_torch = isinstance(image, torch.Tensor)
-
-        # Convert to numpy to use skimage.measure.block_reduce.
-        if image_is_torch:
-            device = image.device
-            dtype = image.dtype
-            image = image.detach().cpu().numpy()
 
         kwargs.pop("func", False)
         kwargs.pop("image", False)
         kwargs.pop("block_size", False)
-
-        pooled_image = utils.safe_call(
+        return utils.safe_call(
             skimage.measure.block_reduce,
             image=image,
             func=self.pooling,
@@ -1196,26 +1188,18 @@ class Pool(Feature):
             **kwargs,
         )
 
-        # Convert back to torch.Tensor if needed.
-        if image_is_torch:
-            return torch.tensor(
-                pooled_image,
-                dtype=dtype,
-                device=device
-            )
-        
-        return pooled_image
-
 
 #TODO ***AL*** revise AveragePooling - torch, typing, docstring, unit test
 class AveragePooling(Pool):
+    # Check if numpy, call super, else use torch.AveragePooling2D
     """Apply average pooling to an image.
 
-    This class reduces the resolution of an image by dividing it into
-    non-overlapping blocks of size `ksize` and applying the average function to
-    each block. The result is a downsampled image where each pixel value
-    represents the average value within the corresponding block of the
-    original image.
+    This class inherits from `Pool` to reduce the resolution of an image by
+    dividing it into non-overlapping blocks of size `ksize` and applying the
+    average function to each block. The result is a downsampled image where
+    each pixel value represents the average value within the corresponding
+    block of the original image. If TORCH_AVAILABLE, it will return the output
+    of `torch.nn.functional.avg_pool2d` instead.
 
     Parameters
     ----------
@@ -1240,10 +1224,12 @@ class AveragePooling(Pool):
 
     Notes
     -----
-    Calling this feature returns a `np.ndarray` by default. If
-    `store_properties` is set to `True`, the returned array will be
-    automatically wrapped in an `Image` object. This behavior is handled
-    internally and does not affect the return type of the `get()` method.
+    Calling this feature returns a pooled image of the input, it will return
+    either numpy or torch depending on the `TORCH_AVAILABLE` flag. If
+    `store_properties` is set to `True` and the input is a numpy array,
+    the returned array will be automatically wrapped in an `Image` object.
+    This behavior is handled internally and does not affect the return type
+    of the `get()` method.
 
     """
 
@@ -1254,7 +1240,8 @@ class AveragePooling(Pool):
     ):
         """Initialize the parameters for average pooling.
 
-        This constructor initializes the parameters for average pooling.
+        This constructor initializes the parameters for average pooling and
+        checks whether to use the numpy or torch implementation.
 
         Parameters
         ----------
@@ -1266,6 +1253,14 @@ class AveragePooling(Pool):
         """
 
         super().__init__(np.mean, ksize=ksize, **kwargs)
+
+        def get(self, image, ksize: int, **kwargs):
+            
+            # Check torch backend and if the type name starts with "torch".
+            # Isinstance will not work when torch is not available.
+            if TORCH_AVAILABLE and type(image).__module__.startswith("torch"):
+                return torch.nn.functional.avg_pool2d(image, kernel_size=ksize)
+            return super().get(image, ksize=ksize, **kwargs)
 
 
 #TODO ***AL*** revise MaxPooling - torch, typing, docstring, unit test

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -155,7 +155,10 @@ from deeptrack.features import DummyFeature, Feature, StructuralFeature
 from deeptrack.image import Image, pad_image_to_fft, maybe_cupy
 from deeptrack.types import ArrayLike, PropertyLike
 
-import torch
+from deeptrack.backend import config, TORCH_AVAILABLE, xp
+
+if TORCH_AVAILABLE:
+    import torch
 
 from deeptrack import image
 from deeptrack import units_registry as u

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -155,11 +155,6 @@ from deeptrack.features import DummyFeature, Feature, StructuralFeature
 from deeptrack.image import Image, pad_image_to_fft, maybe_cupy
 from deeptrack.types import ArrayLike, PropertyLike
 
-from deeptrack.backend import config, TORCH_AVAILABLE, xp
-
-if TORCH_AVAILABLE:
-    import torch
-
 from deeptrack import image
 from deeptrack import units_registry as u
 
@@ -363,8 +358,6 @@ class Microscope(StructuralFeature):
             )
 
             imaged_sample = self._objective.resolve(sample_volume)
-            if self.get_backend() == "torch": 
-                imaged_sample = torch.from_numpy(imaged_sample)
 
         # Upscale given by the optics needs to be handled separately.
         if _upscale_given_by_optics != (1, 1, 1):

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -155,6 +155,8 @@ from deeptrack.features import DummyFeature, Feature, StructuralFeature
 from deeptrack.image import Image, pad_image_to_fft, maybe_cupy
 from deeptrack.types import ArrayLike, PropertyLike
 
+import torch
+
 from deeptrack import image
 from deeptrack import units_registry as u
 
@@ -358,6 +360,8 @@ class Microscope(StructuralFeature):
             )
 
             imaged_sample = self._objective.resolve(sample_volume)
+            if self.get_backend() == "torch": 
+                imaged_sample = torch.from_numpy(imaged_sample)
 
         # Upscale given by the optics needs to be handled separately.
         if _upscale_given_by_optics != (1, 1, 1):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature(input_image)
+            pooled_image = feature.get(input_image)
             self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,10 +113,11 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
                                            [5.0, 6.0, 7.0, 8.0] ]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = torch.tensor(feature.get(input_image, ksize=2))
+            pooled_image = feature.get(input_image, ksize=2)
             
             expected = torch.tensor([[[[3.5, 5.5]]]], dtype=pooled_image.dtype, device=pooled_image.device)
             self.assertEqual(pooled_image.shape, expected.shape)
+
             self.assertTrue(torch.allclose(pooled_image, expected))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -110,11 +110,13 @@ class TestMath(unittest.TestCase):
         self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
 
         if TORCH_AVAILABLE:
-            input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
-                                          [5.0, 6.0, 7.0, 8.0]]]])
+            input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
+                                           [5.0, 6.0, 7.0, 8.0] ]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = torch.tensor(feature.get(input_image, ksize=2))
+            
             expected = torch.tensor([[[[3.5, 5.5]]]], dtype=pooled_image.dtype, device=pooled_image.device)
+            self.assertEqual(pooled_image.shape, expected.shape)
             self.assertTrue(torch.allclose(pooled_image, expected))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -114,7 +114,7 @@ class TestMath(unittest.TestCase):
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = feature.resolve(input_image)
-            self.assertTrue(torch.allclose(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
+            self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature.resolve(input_tensor)
+            pooled_image = feature.resolve(input_image)
             self.AssertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature.resolve(input_image)
+            pooled_image = feature(input_image)
             self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature.get(input_image)
+            pooled_image = feature(input_image)
             self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -111,7 +111,7 @@ class TestMath(unittest.TestCase):
 
         if TORCH_AVAILABLE:
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
-                                            5.0, 6.0, 7.0, 8.0]]]])
+                                          [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = feature.resolve(input_tensor)
             self.AssertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -115,7 +115,7 @@ class TestMath(unittest.TestCase):
             feature = math.AveragePooling(ksize=2)
             pooled_image = feature.get(input_image, ksize=2)
             
-            expected = torch.tensor([[[[3.5, 5.5]]]], dtype=pooled_image.dtype, device=pooled_image.device)
+            expected = torch.tensor([[[[3.5, 5.5]]]])
             self.assertEqual(pooled_image.shape, expected.shape)
 
             self.assertTrue(torch.allclose(pooled_image, expected))

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
                                            [5.0, 6.0, 7.0, 8.0] ]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature.get(input_image, ksize=2)
+            pooled_image = feature(input_image, ksize=2)
             
             expected = torch.tensor([[[[3.5, 5.5]]]])
             self.assertEqual(pooled_image.shape, expected.shape)

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -83,29 +83,18 @@ class TestMath_Numpy(BackendTestBase):
         #self.assertTrue(xp.all(blurred_image == expected_output))
 
     def test_AveragePooling(self):
-        input_image = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=float)
+        input_image = xp.asarray([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=float)
         feature = math.AveragePooling(ksize=2)
         pooled_image = feature.resolve(input_image)
-        self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
-
+        expected = xp.asarray([[3.5, 5.5]])
+        self.assertTrue(xp.all(pooled_image == expected))
 
 # Extending the test and setting the backend to torch
 @unittest.skipUnless(TORCH_AVAILABLE, "PyTorch is not installed.")
 class TestMath_Torch(TestMath_Numpy):
     BACKEND = "torch"
+    pass
     
-    def test_AveragePooling(self):
-        input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
-                                        [5.0, 6.0, 7.0, 8.0] ]]])
-        feature = math.AveragePooling(ksize=2)
-        pooled_image = feature(input_image, ksize=2)
-        expected = torch.tensor([[[[3.5, 5.5]]]])
-        self.assertEqual(pooled_image.shape, expected.shape)
-        self.assertTrue(torch.allclose(pooled_image, expected))
-
-    
-
-
 class TestMath(unittest.TestCase):
 
     def test_GaussianBlur(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -82,12 +82,27 @@ class TestMath_Numpy(BackendTestBase):
         #blurred_image = feature.resolve(input_image)
         #self.assertTrue(xp.all(blurred_image == expected_output))
 
+    def test_AveragePooling(self):
+        input_image = np.array([[1, 2, 3, 4], [5, 6, 7, 8]], dtype=float)
+        feature = math.AveragePooling(ksize=2)
+        pooled_image = feature.resolve(input_image)
+        self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
+
 
 # Extending the test and setting the backend to torch
 @unittest.skipUnless(TORCH_AVAILABLE, "PyTorch is not installed.")
 class TestMath_Torch(TestMath_Numpy):
     BACKEND = "torch"
-    pass
+
+    input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
+                                    [5.0, 6.0, 7.0, 8.0] ]]])
+    feature = math.AveragePooling(ksize=2)
+    pooled_image = feature(input_image, ksize=2)
+    expected = torch.tensor([[[[3.5, 5.5]]]])
+    self.assertEqual(pooled_image.shape, expected.shape)
+    self.assertTrue(torch.allclose(pooled_image, expected))
+
+    
 
 
 class TestMath(unittest.TestCase):
@@ -109,16 +124,6 @@ class TestMath(unittest.TestCase):
         pooled_image = feature.resolve(input_image)
         self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
 
-        if TORCH_AVAILABLE:
-            input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
-                                           [5.0, 6.0, 7.0, 8.0] ]]])
-            feature = math.AveragePooling(ksize=2)
-            pooled_image = feature(input_image, ksize=2)
-            
-            expected = torch.tensor([[[[3.5, 5.5]]]])
-            self.assertEqual(pooled_image.shape, expected.shape)
-
-            self.assertTrue(torch.allclose(pooled_image, expected))
 
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -114,7 +114,7 @@ class TestMath(unittest.TestCase):
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = feature.resolve(input_image)
-            self.assertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
+            self.assertTrue(torch.allclose(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -114,7 +114,8 @@ class TestMath(unittest.TestCase):
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = torch.tensor(feature.get(input_image, ksize=2))
-            self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
+            expected = torch.tensor([[[[3.5, 5.5]]]], dtype=pooled_image.dtype, device=pooled_image.device)
+            self.assertTrue(torch.allclose(pooled_image, expected))
 
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -114,7 +114,7 @@ class TestMath(unittest.TestCase):
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
             pooled_image = feature.resolve(input_image)
-            self.AssertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
+            self.assertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature.get(input_image, ksize=2)
+            pooled_image = torch.tensor(feature.get(input_image, ksize=2))
             self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -109,6 +109,13 @@ class TestMath(unittest.TestCase):
         pooled_image = feature.resolve(input_image)
         self.assertTrue(np.all(pooled_image == [[3.5, 5.5]]))
 
+        if TORCH_AVAILABLE:
+            input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
+                                            5.0, 6.0, 7.0, 8.0]]]])
+            feature = math.AveragePooling(ksize=2)
+            pooled_image = feature.resolve(input_tensor)
+            self.AssertTrue(torch.all(pooled_image == torch.tensor([[[[3.5, 5.5]]]])))
+
     def test_MaxPooling(self):
         input_image = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         feature = math.MaxPooling(ksize=2)

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -113,7 +113,7 @@ class TestMath(unittest.TestCase):
             input_image = torch.tensor([[[[1.0, 2.0, 3.0, 4.0],
                                           [5.0, 6.0, 7.0, 8.0]]]])
             feature = math.AveragePooling(ksize=2)
-            pooled_image = feature(input_image)
+            pooled_image = feature.get(input_image, ksize=2)
             self.assertTrue(torch.allclose(pooled_image, torch.tensor([[[[3.5, 5.5]]]])))
 
     def test_MaxPooling(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -93,14 +93,15 @@ class TestMath_Numpy(BackendTestBase):
 @unittest.skipUnless(TORCH_AVAILABLE, "PyTorch is not installed.")
 class TestMath_Torch(TestMath_Numpy):
     BACKEND = "torch"
-
-    input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
-                                    [5.0, 6.0, 7.0, 8.0] ]]])
-    feature = math.AveragePooling(ksize=2)
-    pooled_image = feature(input_image, ksize=2)
-    expected = torch.tensor([[[[3.5, 5.5]]]])
-    self.assertEqual(pooled_image.shape, expected.shape)
-    self.assertTrue(torch.allclose(pooled_image, expected))
+    
+    def test_AveragePooling(self):
+        input_image = torch.tensor([[[ [1.0, 2.0, 3.0, 4.0],
+                                        [5.0, 6.0, 7.0, 8.0] ]]])
+        feature = math.AveragePooling(ksize=2)
+        pooled_image = feature(input_image, ksize=2)
+        expected = torch.tensor([[[[3.5, 5.5]]]])
+        self.assertEqual(pooled_image.shape, expected.shape)
+        self.assertTrue(torch.allclose(pooled_image, expected))
 
     
 


### PR DESCRIPTION
Docs, torch, unit tests for averagepooling.
Unit test currently failing as `develop/deeptrack2/optics.py` does not have torch backend support yet.
AveragePooling is used in line 364 of `optics.py`.

The errors are caused in various unit tests due to numpy arrays being passed to `torch.nn.functional.avg_pool2d` with a torch backend in `math.py`, so this will need to be looked at.

