### PR TITLE
Update math/resize

### DIFF
--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1516,7 +1516,7 @@ class Resize(Feature):
         dsize: tuple[int, int]
             Desired output size of the image as (width, height).
         **kwargs: Any
-            Additional keyword arguments passed to the resize function.
+            Additional keyword arguments passed to `cv2.resize`.
 
         Returns
         -------
@@ -1553,7 +1553,6 @@ class Resize(Feature):
                 size=[dsize[1], dsize[0]],
                 mode="bilinear",
                 align_corners=False,
-                **kwargs,
             )
 
             # Restore original dimensionallity

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1444,64 +1444,83 @@ class MedianPooling(Pool):
         super().__init__(np.median, ksize=ksize, **kwargs)
 
 
-#TODO ***MG*** revise Resize - torch, typing, docstring, unit test
 class Resize(Feature):
-    """Resize an image to a specified size.
+    """
+    Resize an image to a specified size.
 
-    This class is a wrapper around cv2.resize and resizes an image to a
-    specified size. The `dsize` parameter specifies the desired output size of
-    the image.
-    Note that the order of the axes is different in cv2 and numpy. In cv2, the
-    first axis is the vertical axis, while in numpy it is the horizontal axis.
-    This is reflected in the default values of the arguments.
+    This class resizes an image to a specified size using OpenCV (`cv2.resize`)
+    for NumPy arrays or `torch.nn.functional.interpolate` for PyTorch tensors.
+    The `dsize` parameter specifies the desired output size as (width, height).
 
     Parameters
     ----------
-    dsize: tuple
-        Size to resize to.
+    dsize: PropertyLike[tuple[int, int]]
+        The target size as (width, height).
     **kwargs: Any
-        Additional parameters sent to the resizing function.
+        Additional parameters sent to the underlying resize function.
+
+    Methods
+    -------
+    get(
+        image: np.ndarray | torch.Tensor, dsize: tuple[int, int], **kwargs
+    ) -> np.ndarray | torch.Tensor
+        Resize the input image to the specified size.
+
+    Examples
+    --------
+    >>> import deeptrack as dt
+    >>> import numpy as np
+
+    Create an image:
+    >>> input_image = np.random.rand(16, 16)
+
+    Resize it to (8, 8):
+    >>> feature = dt.math.Resize(dsize=(8, 4))
+    >>> resized_image = feature.resolve(input_image)
+    >>> resized_image.shape
+    (4, 8)
 
     """
 
     def __init__(
         self: Resize,
-        dsize: PropertyLike[tuple] = (256, 256),
+        dsize: PropertyLike[tuple[int, int]] = (256, 256),
         **kwargs: Any,
     ):
-        """Initialize the parameters for resizing input features.
-
-        This constructor initializes the parameters for resizing input
-        features.
+        """
+        Initialize the parameters for the Resize feature.
 
         Parameters
         ----------
-        dsize: tuple
-            Size to resize to.
+        dsize: PropertyLike[tuple[int, int]]
+            The target size as (width, height).
         **kwargs: Any
-            Additional keyword arguments.
+            Additional arguments passed to the parent `Feature` class.
 
         """
-
         super().__init__(dsize=dsize, **kwargs)
 
-    def get(self: Resize, image: np.ndarray, dsize: tuple, **kwargs: Any) -> np.ndarray:
-        """Resize the input image to the specified size.
-
-        This method resizes the input image to the specified size.
+    def get(
+            self: Resize,
+            image: NDArray,
+            dsize: tuple[int, int],
+            **kwargs: Any
+        ) -> NDArray:
+        """
+        Resize the input image to the specified size.
 
         Parameters
         ----------
-        image: np.ndarray
+        image: np.ndarray or torch.Tensor
             The input image to resize.
-        dsize: tuple
-            Desired output size of the image.
+        dsize: tuple[int, int]
+            Desired output size of the image as (width, height).
         **kwargs: Any
-            Additional keyword arguments.
+            Additional keyword arguments passed to the resize function.
 
         Returns
         -------
-        np.ndarray
+        np.ndarray or torch.Tensor
             The resized image.
 
         """
@@ -1512,7 +1531,43 @@ class Resize(Feature):
         if self._wrap_array_with_image:
             image = strip(image)
 
-        return utils.safe_call(cv2.resize, positional_args=[image, dsize], **kwargs)
+        if apc.is_torch_array(image):
+            original_ndim = image.ndim
+
+            # Reshape input to (N, C, H, W)
+            if image.ndim == 1:
+                image = image.unsqueeze(1).unsqueeze(0).unsqueeze(0)
+            elif image.ndim == 2:
+                image = image.unsqueeze(0).unsqueeze(0)
+            elif image.ndim == 3:
+                image = image.permute(2, 0, 1).unsqueeze(0)
+                if image.shape[1] == 1:
+                    original_ndim = 2                   
+            else:
+                raise ValueError(
+                    "Resize not supported for tensor with ndim > 3"
+                )
+
+            resized = torch.nn.functional.interpolate(
+                image,
+                size=[dsize[1], dsize[0]],
+                mode='bilinear',
+                align_corners=False,
+                **kwargs,
+            )
+
+            # Restore original dimensionallity
+            if original_ndim == 1 or original_ndim == 2:
+                resized = resized.squeeze(0).squeeze(0)
+            elif original_ndim == 3:
+                resized = resized.squeeze(0).permute(1, 2, 0)
+
+            return resized
+        
+        else:
+            return utils.safe_call(
+                cv2.resize, positional_args=[image, dsize], **kwargs
+            )
 
 
 if OPENCV_AVAILABLE:

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1501,11 +1501,11 @@ class Resize(Feature):
         super().__init__(dsize=dsize, **kwargs)
 
     def get(
-            self: Resize,
-            image: NDArray,
-            dsize: tuple[int, int],
-            **kwargs: Any
-        ) -> NDArray:
+        self: Resize,
+        image: NDArray | torch.Tensor,
+        dsize: tuple[int, int],
+        **kwargs: Any,
+    ) -> NDArray | torch.Tensor:
         """
         Resize the input image to the specified size.
 
@@ -1542,7 +1542,7 @@ class Resize(Feature):
             elif image.ndim == 3:
                 image = image.permute(2, 0, 1).unsqueeze(0)
                 if image.shape[1] == 1:
-                    original_ndim = 2                   
+                    original_ndim = 2
             else:
                 raise ValueError(
                     "Resize not supported for tensor with ndim > 3"
@@ -1551,7 +1551,7 @@ class Resize(Feature):
             resized = torch.nn.functional.interpolate(
                 image,
                 size=[dsize[1], dsize[0]],
-                mode='bilinear',
+                mode="bilinear",
                 align_corners=False,
                 **kwargs,
             )
@@ -1563,7 +1563,7 @@ class Resize(Feature):
                 resized = resized.squeeze(0).permute(1, 2, 0)
 
             return resized
-        
+
         else:
             return utils.safe_call(
                 cv2.resize, positional_args=[image, dsize], **kwargs

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1445,10 +1445,9 @@ class MedianPooling(Pool):
 
 
 class Resize(Feature):
-    """
-    Resize an image to a specified size.
+    """Resize an image to a specified size.
 
-    This class resizes an image using:
+    `Resize` resizes an image using:
       - OpenCV (`cv2.resize`) for NumPy arrays.
       - PyTorch (`torch.nn.functional.interpolate`) for PyTorch tensors.
 
@@ -1457,7 +1456,6 @@ class Resize(Feature):
       - **NumPy (OpenCV)**: `dsize` is given as `(width, height)` to match
         OpenCV’s default.
       - **PyTorch**: `dsize` is given as `(height, width)`.
-
 
     Parameters
     ----------
@@ -1505,8 +1503,7 @@ class Resize(Feature):
         dsize: PropertyLike[tuple[int, int]] = (256, 256),
         **kwargs: Any,
     ):
-        """
-        Initialize the parameters for the Resize feature.
+        """Initialize the parameters for the Resize feature.
 
         Parameters
         ----------
@@ -1517,6 +1514,7 @@ class Resize(Feature):
             Additional arguments passed to the parent `Feature` class.
 
         """
+
         super().__init__(dsize=dsize, **kwargs)
 
     def get(
@@ -1525,8 +1523,7 @@ class Resize(Feature):
         dsize: tuple[int, int],
         **kwargs: Any,
     ) -> NDArray | torch.Tensor:
-        """
-        Resize the input image to the specified size.
+        """Resize the input image to the specified size.
 
         Parameters
         ----------

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1557,9 +1557,6 @@ class Resize(Feature):
 
         """
 
-        import cv2
-        from deeptrack import config
-
         if self._wrap_array_with_image:
             image = strip(image)
 
@@ -1593,6 +1590,7 @@ class Resize(Feature):
             return resized
 
         else:
+            import cv2
             return utils.safe_call(
                 cv2.resize, positional_args=[image, dsize], **kwargs
             )

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1448,16 +1448,26 @@ class Resize(Feature):
     """
     Resize an image to a specified size.
 
-    This class resizes an image to a specified size using OpenCV (`cv2.resize`)
-    for NumPy arrays or `torch.nn.functional.interpolate` for PyTorch tensors.
-    The `dsize` parameter specifies the desired output size as (width, height).
+    This class resizes an image using:
+      - OpenCV (`cv2.resize`) for NumPy arrays.
+      - PyTorch (`torch.nn.functional.interpolate`) for PyTorch tensors.
+
+    The interpretation of the `dsize` parameter follows the convention 
+    of the underlying backend:
+      - **NumPy (OpenCV)**: ``dsize`` is given as ``(width, height)`` to match
+        OpenCV’s default.
+      - **PyTorch**: ``dsize`` is given as ``(height, width)``.
+
 
     Parameters
     ----------
     dsize: PropertyLike[tuple[int, int]]
-        The target size as (width, height).
+        The target size. Format depends on backend: ``(width, height)`` for
+        NumPy, ``(height, width)`` for PyTorch.
     **kwargs: Any
-        Additional parameters sent to the underlying resize function.
+        Additional parameters sent to the underlying resize function:
+          - NumPy: passed to ``cv2.resize``.
+          - PyTorch: passed to ``torch.nn.functional.interpolate``.
 
     Methods
     -------
@@ -1469,16 +1479,22 @@ class Resize(Feature):
     Examples
     --------
     >>> import deeptrack as dt
+
+    Numpy example:
     >>> import numpy as np
-
-    Create an image:
-    >>> input_image = np.random.rand(16, 16)
-
-    Resize it to (8, 8):
-    >>> feature = dt.math.Resize(dsize=(8, 4))
-    >>> resized_image = feature.resolve(input_image)
-    >>> resized_image.shape
+    >>> input_image = np.random.rand(16, 16)            # Create image
+    >>> feature = dt.math.Resize(dsize=(8, 4))          # (width=8, height=4)
+    >>> resized_image = feature.resolve(input_image)    # Resize it to (4, 8)
+    >>> print(resized_image.shape)
     (4, 8)
+
+    PyTorch example:
+    >>> import torch
+    >>> input_image = torch.rand(1, 1, 16, 16)          # Create image
+    >>> feature = dt.math.Resize(dsize=(4, 8))          # (height=4, width=8)
+    >>> resized_image = feature.resolve(input_image)    # Resize it to (4, 8)
+    >>> print(resized_image.shape)
+    torch.Size([1, 1, 4, 8])
 
     """
 
@@ -1493,7 +1509,8 @@ class Resize(Feature):
         Parameters
         ----------
         dsize: PropertyLike[tuple[int, int]]
-            The target size as (width, height).
+            The target size. Format depends on backend: ``(width, height)`` for
+            NumPy, ``(height, width)`` for PyTorch. Default is (256, 256).
         **kwargs: Any
             Additional arguments passed to the parent `Feature` class.
 
@@ -1513,15 +1530,30 @@ class Resize(Feature):
         ----------
         image: np.ndarray or torch.Tensor
             The input image to resize.
+            - NumPy arrays may be grayscale (H, W) or color (H, W, C).
+            - Torch tensors are expected to be (N, C, H, W), but (C, H, W) or
+              (H, W) are also accepted.
         dsize: tuple[int, int]
-            Desired output size of the image as (width, height).
+            Desired output size of the image.
+            - NumPy: (width, height)
+            - PyTorch: (height, width)
         **kwargs: Any
-            Additional keyword arguments passed to `cv2.resize`.
+            Additional keyword arguments passed to the underlying resize 
+            function (`cv2.resize` or `torch.nn.functional.interpolate`).
 
         Returns
         -------
         np.ndarray or torch.Tensor
-            The resized image.
+            The resized image in the same type and dimensionality format as
+            input.
+
+        Notes
+        -----
+        - For PyTorch tensors, resizing uses bilinear interpolation with
+          `align_corners=False`. This choice is made to match the default
+          behavior of OpenCV’s `cv2.resize` when working with NumPy arrays, so
+          that resizing the same image with either backend produces as close to
+          identical results as possible.
 
         """
 
@@ -1532,34 +1564,31 @@ class Resize(Feature):
             image = strip(image)
 
         if apc.is_torch_array(image):
-            original_ndim = image.ndim
+            original_shape = image.shape
 
             # Reshape input to (N, C, H, W)
-            if image.ndim == 1:
-                image = image.unsqueeze(1).unsqueeze(0).unsqueeze(0)
-            elif image.ndim == 2:
+            if image.ndim == 2:     # (H, W)
                 image = image.unsqueeze(0).unsqueeze(0)
-            elif image.ndim == 3:
-                image = image.permute(2, 0, 1).unsqueeze(0)
-                if image.shape[1] == 1:
-                    original_ndim = 2
-            else:
+            elif image.ndim == 3:   # (C, H, W)
+                image = image.unsqueeze(0)
+            elif image.ndim != 4:
                 raise ValueError(
-                    "Resize not supported for tensor with ndim > 3"
+                    "Resize only supported for tensor of shape (N, C, H, W), "
+                    "(C, H, W), or (H, W)."
                 )
 
             resized = torch.nn.functional.interpolate(
                 image,
-                size=[dsize[1], dsize[0]],
+                size=dsize,
                 mode="bilinear",
                 align_corners=False,
             )
 
-            # Restore original dimensionallity
-            if original_ndim == 1 or original_ndim == 2:
+            # Restore original dimensionality
+            if len(original_shape) == 2:
                 resized = resized.squeeze(0).squeeze(0)
-            elif original_ndim == 3:
-                resized = resized.squeeze(0).permute(1, 2, 0)
+            elif len(original_shape) == 3:
+                resized = resized.squeeze(0)
 
             return resized
 

--- a/deeptrack/math.py
+++ b/deeptrack/math.py
@@ -1454,20 +1454,20 @@ class Resize(Feature):
 
     The interpretation of the `dsize` parameter follows the convention 
     of the underlying backend:
-      - **NumPy (OpenCV)**: ``dsize`` is given as ``(width, height)`` to match
+      - **NumPy (OpenCV)**: `dsize` is given as `(width, height)` to match
         OpenCV’s default.
-      - **PyTorch**: ``dsize`` is given as ``(height, width)``.
+      - **PyTorch**: `dsize` is given as `(height, width)`.
 
 
     Parameters
     ----------
     dsize: PropertyLike[tuple[int, int]]
-        The target size. Format depends on backend: ``(width, height)`` for
-        NumPy, ``(height, width)`` for PyTorch.
+        The target size. Format depends on backend: `(width, height)` for
+        NumPy, `(height, width)` for PyTorch.
     **kwargs: Any
         Additional parameters sent to the underlying resize function:
-          - NumPy: passed to ``cv2.resize``.
-          - PyTorch: passed to ``torch.nn.functional.interpolate``.
+          - NumPy: passed to `cv2.resize`.
+          - PyTorch: passed to `torch.nn.functional.interpolate`.
 
     Methods
     -------
@@ -1482,6 +1482,7 @@ class Resize(Feature):
 
     Numpy example:
     >>> import numpy as np
+    >>>
     >>> input_image = np.random.rand(16, 16)            # Create image
     >>> feature = dt.math.Resize(dsize=(8, 4))          # (width=8, height=4)
     >>> resized_image = feature.resolve(input_image)    # Resize it to (4, 8)
@@ -1490,6 +1491,7 @@ class Resize(Feature):
 
     PyTorch example:
     >>> import torch
+    >>>
     >>> input_image = torch.rand(1, 1, 16, 16)          # Create image
     >>> feature = dt.math.Resize(dsize=(4, 8))          # (height=4, width=8)
     >>> resized_image = feature.resolve(input_image)    # Resize it to (4, 8)
@@ -1509,8 +1511,8 @@ class Resize(Feature):
         Parameters
         ----------
         dsize: PropertyLike[tuple[int, int]]
-            The target size. Format depends on backend: ``(width, height)`` for
-            NumPy, ``(height, width)`` for PyTorch. Default is (256, 256).
+            The target size. Format depends on backend: `(width, height)` for
+            NumPy, `(height, width)` for PyTorch. Default is (256, 256).
         **kwargs: Any
             Additional arguments passed to the parent `Feature` class.
 
@@ -1531,8 +1533,8 @@ class Resize(Feature):
         image: np.ndarray or torch.Tensor
             The input image to resize.
             - NumPy arrays may be grayscale (H, W) or color (H, W, C).
-            - Torch tensors are expected to be (N, C, H, W), but (C, H, W) or
-              (H, W) are also accepted.
+            - Torch tensors are expected in one of the following formats:
+              (N, C, H, W), (C, H, W), or (H, W).
         dsize: tuple[int, int]
             Desired output size of the image.
             - NumPy: (width, height)
@@ -1550,10 +1552,9 @@ class Resize(Feature):
         Notes
         -----
         - For PyTorch tensors, resizing uses bilinear interpolation with
-          `align_corners=False`. This choice is made to match the default
-          behavior of OpenCV’s `cv2.resize` when working with NumPy arrays, so
-          that resizing the same image with either backend produces as close to
-          identical results as possible.
+          `align_corners=False`. This choice matches OpenCV’s `cv2.resize`
+          default behavior when resizing NumPy arrays, aiming to produce nearly
+          identical results between both backends.
 
         """
 
@@ -1570,7 +1571,7 @@ class Resize(Feature):
                 image = image.unsqueeze(0)
             elif image.ndim != 4:
                 raise ValueError(
-                    "Resize only supported for tensor of shape (N, C, H, W), "
+                    "Resize only supports tensors with shape (N, C, H, W), "
                     "(C, H, W), or (H, W)."
                 )
 

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -142,31 +142,33 @@ class TestMath(unittest.TestCase):
         self.assertIsInstance(resized, np.ndarray)
         self.assertEqual(resized.shape, (4, 8))
 
-        ### Test with PyTorch tensor (if available)
-        if TORCH_AVAILABLE:
-            input_shapes = [
-                (16,),
-                (16, 16),
-                (16, 16, 1),
-                (16, 16, 4),
-            ]
+    @unittest.skipUnless(TORCH_AVAILABLE, "PyTorch is not installed.")
+    def test_Resize_torch(self):
 
-            feature = math.Resize(dsize=(8, 4))
+        feature = math.Resize(dsize=(4, 8))
 
-            for shape in input_shapes:
-                with self.subTest(shape=shape):
-                    input_image = torch.rand(*shape)
-                    resized = feature.resolve(input_image)
+        input_image = torch.rand(16, 16)
+        resized = feature.resolve(input_image)
+        self.assertIsInstance(resized, torch.Tensor)
+        self.assertEqual(tuple(resized.shape), (4, 8))
 
-                    self.assertIsInstance(resized, torch.Tensor)
+        # Compare with NumPy version:
+        feature_np = math.Resize(dsize=(8, 4))
+        input_image_np = input_image.numpy()
+        resized_np = feature_np.resolve(input_image_np)
+        np.testing.assert_allclose(
+                    resized_np, resized.numpy(), rtol=1e-5, atol=1e-5
+                )
 
-                    # Compare with NumPy version:
-                    input_image_np = input_image.numpy()
-                    resized_np = feature.resolve(input_image_np)
-                    self.assertEqual(tuple(resized.shape), resized_np.shape)
-                    np.testing.assert_allclose(
-                        resized_np, resized.numpy(), rtol=1e-5, atol=1e-5
-                    )
+        input_image = torch.rand(3, 16, 16)
+        resized = feature.resolve(input_image)
+        self.assertIsInstance(resized, torch.Tensor)
+        self.assertEqual(tuple(resized.shape), (3, 4, 8))
+
+        input_image = torch.rand(1, 1, 16, 16)
+        resized = feature.resolve(input_image)
+        self.assertIsInstance(resized, torch.Tensor)
+        self.assertEqual(tuple(resized.shape), (1, 1, 4, 8))
 
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_BlurCV2_GaussianBlur(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -152,13 +152,14 @@ class TestMath(unittest.TestCase):
         self.assertIsInstance(resized, torch.Tensor)
         self.assertEqual(tuple(resized.shape), (4, 8))
 
-        # Compare with NumPy version:
-        feature_np = math.Resize(dsize=(8, 4))
-        input_image_np = input_image.numpy()
-        resized_np = feature_np.resolve(input_image_np)
-        np.testing.assert_allclose(
-                    resized_np, resized.numpy(), rtol=1e-5, atol=1e-5
-                )
+        if OPENCV_AVAILABLE:
+            # Compare with NumPy version:
+            feature_np = math.Resize(dsize=(8, 4))
+            input_image_np = input_image.numpy()
+            resized_np = feature_np.resolve(input_image_np)
+            np.testing.assert_allclose(
+                        resized_np, resized.numpy(), rtol=1e-5, atol=1e-5
+                    )
 
         input_image = torch.rand(3, 16, 16)
         resized = feature.resolve(input_image)

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -136,11 +136,37 @@ class TestMath(unittest.TestCase):
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_Resize(self):
         input_image = np.random.rand(16, 16)
-        feature = math.Resize(dsize=(8, 8))
+        feature = math.Resize(dsize=(8, 4))
         resized = feature.resolve(input_image)
 
         self.assertIsInstance(resized, np.ndarray)
-        self.assertEqual(resized.shape, (8, 8))
+        self.assertEqual(resized.shape, (4, 8))
+
+        ### Test with PyTorch tensor (if available)
+        if TORCH_AVAILABLE:
+            input_shapes = [
+                (16,),
+                (16, 16),
+                (16, 16, 1),
+                (16, 16, 4),
+            ]
+
+            feature = math.Resize(dsize=(8, 4))
+
+            for shape in input_shapes:
+                with self.subTest(shape=shape):
+                    input_image = torch.rand(*shape)
+                    resized = feature.resolve(input_image)
+
+                    self.assertIsInstance(resized, torch.Tensor)
+
+                    # Compare with NumPy version:
+                    input_image_np = input_image.numpy()
+                    resized_np = feature.resolve(input_image_np)
+                    self.assertEqual(tuple(resized.shape), resized_np.shape)
+                    np.testing.assert_allclose(
+                        resized_np, resized.numpy(), rtol=1e-5, atol=1e-5
+                    )
 
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")
     def test_BlurCV2_GaussianBlur(self):

--- a/deeptrack/tests/test_math.py
+++ b/deeptrack/tests/test_math.py
@@ -138,6 +138,8 @@ class TestMath(unittest.TestCase):
         input_image = np.random.rand(16, 16)
         feature = math.Resize(dsize=(8, 8))
         resized = feature.resolve(input_image)
+
+        self.assertIsInstance(resized, np.ndarray)
         self.assertEqual(resized.shape, (8, 8))
 
     @unittest.skipUnless(OPENCV_AVAILABLE, "OpenCV is not installed.")


### PR DESCRIPTION
Updated docs of math/resize. 

Made it compatible with torch, with a focus on getting the same results regardless if the input is a numpy array or a torch tensor.

Updated the unittesting, and included tests for torch