### PR TITLE
Update optics/pupil

### DIFF
--- a/deeptrack/image.py
+++ b/deeptrack/image.py
@@ -1730,10 +1730,11 @@ def pad_image_to_fft(
 
     Examples
     --------
-    >>> import numpy as np
     >>> from deeptrack.image import Image, pad_image_to_fft
 
     Pad an Image object:
+    >>> import numpy as np
+    >>>
     >>> img = Image(np.ones((7, 13)))
     >>> padded_img = pad_image_to_fft(img)
     >>> print(padded_img.shape)
@@ -1746,6 +1747,8 @@ def pad_image_to_fft(
     (6, 12)
 
     Pad a PyTorch tensor:
+    >>> import torch
+    >>>
     >>> img = torch.ones(7, 11)
     >>> padded_img = pad_image_to_fft(img)
     >>> print(padded_img.shape)
@@ -1757,7 +1760,7 @@ def pad_image_to_fft(
         dim: int,
     ) -> int:
 
-        # Returns the smallest value from _FASTEST_SIZES that is >= dim.
+        # Return the smallest value from _FASTEST_SIZES that is >= dim.
         for size in _FASTEST_SIZES:
             if size >= dim:
                 return size

--- a/deeptrack/image.py
+++ b/deeptrack/image.py
@@ -96,10 +96,16 @@ from __future__ import annotations
 import operator as ops
 from typing import Any, Callable, Iterable
 
+import array_api_compat as apc
 import numpy as np
+from numpy.typing import NDArray
 
+from deeptrack.backend import config, TORCH_AVAILABLE, xp
 from deeptrack.properties import Property
 from deeptrack.types import NumberLike
+
+if TORCH_AVAILABLE:
+    import torch
 
 
 #TODO ***??*** revise _binary_method - typing, docstring, unit test
@@ -1694,11 +1700,10 @@ for n in range(1, 10):
 _FASTEST_SIZES = np.sort(_FASTEST_SIZES)
 
 
-#TODO ***??*** revise pad_image_to_fft - typing, docstring, unit test
 def pad_image_to_fft(
-    image: Image | np.ndarray | np.ndarray,
+    image: Image | NDArray | torch.Tensor,
     axes: Iterable[int] = (0, 1),
-) -> Image | np.ndarray:
+) -> Image | NDArray | torch.Tensor:
     """Pads an image to optimize Fast Fourier Transform (FFT) performance.
 
     This function pads an image by adding zeros to the end of specified axes
@@ -1707,7 +1712,7 @@ def pad_image_to_fft(
 
     Parameters
     ----------
-    image: Image | np.ndarray
+    image: Image | np.ndarray | torch.tensor
         The input image to pad. It should be an instance of the `Image` class
         or any array-like structure compatible with FFT operations.
     axes: Iterable[int], optional
@@ -1715,7 +1720,7 @@ def pad_image_to_fft(
 
     Returns
     -------
-    Image | np.ndarray
+    Image | np.ndarray | torch.tensor
         The padded image with dimensions optimized for FFT performance.
 
     Raises
@@ -1729,18 +1734,22 @@ def pad_image_to_fft(
     >>> from deeptrack.image import Image, pad_image_to_fft
 
     Pad an Image object:
-
-    >>> img = Image(np.zeros((7, 13)))
+    >>> img = Image(np.ones((7, 13)))
     >>> padded_img = pad_image_to_fft(img)
     >>> print(padded_img.shape)
     (8, 16)
 
     Pad a NumPy array:
-
-    >>> img = np.zeros((5, 11)))
+    >>> img = np.ones((5, 11))
     >>> padded_img = pad_image_to_fft(img)
     >>> print(padded_img.shape)
     (6, 12)
+
+    Pad a PyTorch tensor:
+    >>> img = torch.ones(7, 11)
+    >>> padded_img = pad_image_to_fft(img)
+    >>> print(padded_img.shape)
+    (8, 12)
 
     """
 
@@ -1748,7 +1757,7 @@ def pad_image_to_fft(
         dim: int,
     ) -> int:
 
-        # Returns the smallest value frin _FASTEST_SIZES larger than dim.
+        # Returns the smallest value from _FASTEST_SIZES that is >= dim.
         for size in _FASTEST_SIZES:
             if size >= dim:
                 return size
@@ -1763,7 +1772,18 @@ def pad_image_to_fft(
         new_shape[axis] = _closest(new_shape[axis])
 
     # Calculate the padding for each axis.
-    pad_width = [(0, increase) for increase in np.array(new_shape) - image.shape]
+    pad_width = [
+        (0, increase)
+        for increase in np.array(new_shape) - np.array(image.shape)
+    ]
 
-    # Pad the image using constant mode (add zeros).
+    # Apply zero-padding with torch.nn.functional.pad if the input is a
+    # PyTorch tensor
+    if apc.is_torch_array(image):
+        pad = []
+        for before, after in reversed(pad_width):
+            pad.extend([before, after])
+        return torch.nn.functional.pad(image, pad, mode="constant", value=0)
+
+    # Apply zero-padding with np.pad if the input is a NumPy array or an Image
     return np.pad(image, pad_width, mode="constant")

--- a/deeptrack/image.py
+++ b/deeptrack/image.py
@@ -1704,7 +1704,7 @@ def pad_image_to_fft(
     image: Image | NDArray | torch.Tensor,
     axes: Iterable[int] = (0, 1),
 ) -> Image | NDArray | torch.Tensor:
-    """Pads an image to optimize Fast Fourier Transform (FFT) performance.
+    """Pad an image to optimize Fast Fourier Transform (FFT) performance.
 
     This function pads an image by adding zeros to the end of specified axes
     so that their lengths match the nearest larger size in `_FASTEST_SIZES`.

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -140,9 +140,12 @@ from pint import Quantity
 from typing import Any
 import warnings
 
+import array_api_compat as apc
 import numpy as np
+from numpy.typing import NDArray
 from scipy.ndimage import convolve
 
+from deeptrack.backend import config, TORCH_AVAILABLE, xp
 from deeptrack.backend.units import (
     ConversionTable,
     create_context,
@@ -157,6 +160,9 @@ from deeptrack.types import ArrayLike, PropertyLike
 
 from deeptrack import image
 from deeptrack import units_registry as u
+
+if TORCH_AVAILABLE:
+    import torch
 
 
 #TODO ***??*** revise Microscope - torch, typing, docstring, unit test
@@ -694,11 +700,11 @@ class Optics(Feature):
         NA: float,
         wavelength: float,
         refractive_index_medium: float,
-        include_aberration: bool = True,   
+        include_aberration: bool = True,
         defocus: float | ArrayLike[float] = 0,
         **kwargs: Any,
     ):
-        """Calculates the pupil function at different focal points.
+        """Calculate the pupil function at different focal points.
 
         Parameters
         ----------
@@ -739,56 +745,81 @@ class Optics(Feature):
         ... )
         >>> print(pupil.shape)
         (1, 128, 128)
-        
+
         """
 
         # Calculates the pupil at each z-position in defocus.
         voxel_size = get_active_voxel_size()
-        shape = np.array(shape)
 
-        # Pupil radius
-        R = NA / wavelength * np.array(voxel_size)[:2]
+        if config.get_backend() == "numpy":
+            shape = np.array(shape)
+
+            # Pupil radius
+            R = NA / wavelength * np.array(voxel_size)[:2]
+
+        elif config.get_backend() == "torch":
+            shape = torch.tensor(shape)
+
+            # Pupil radius
+            R = NA / wavelength * torch.tensor(voxel_size)[:2]
+
+        else:
+            raise ValueError(f"Unsupported backend: {config.get_backend()}")
+
 
         x_radius = R[0] * shape[0]
         y_radius = R[1] * shape[1]
 
-        x = (np.linspace(-(shape[0] / 2), shape[0] / 2 - 1, shape[0])) / x_radius + 1e-8
-        y = (np.linspace(-(shape[1] / 2), shape[1] / 2 - 1, shape[1])) / y_radius + 1e-8
+        x = (
+            xp.linspace(-(shape[0] / 2), shape[0] / 2 - 1, shape[0])
+        ) / x_radius + 1e-8
+        y = (
+            xp.linspace(-(shape[1] / 2), shape[1] / 2 - 1, shape[1])
+        ) / y_radius + 1e-8
 
-        W, H = np.meshgrid(y, x)
-        RHO = (W ** 2 + H ** 2).astype(complex)
-        pupil_function = Image((RHO < 1) + 0.0j, copy=False)
+        W, H = xp.meshgrid(y, x, indexing='xy')
+        
+        if config.get_backend() == "numpy":
+            RHO = (W ** 2 + H ** 2).astype(complex)
+        else:
+            RHO = (W ** 2 + H ** 2).to(dtype=torch.complex64)
+            RHO = RHO.numpy()                                       # not to be kept, only to make it compatible with Image at the moment
+
+        pupil_function = Image((RHO < 1) + 0.0j, copy=False)        # what should we do about this?
         # Defocus
         z_shift = Image(
             2
-            * np.pi
+            * np.pi                                     # should be xp.pi
             * refractive_index_medium
             / wavelength
             * voxel_size[2]
-            * np.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO),
+            * np.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO),   # should be xp.sqrt
             copy=False,
         )
 
         z_shift._value[z_shift._value.imag != 0] = 0
 
         try:
-            z_shift = np.nan_to_num(z_shift, False, 0, 0, 0)
+            z_shift = np.nan_to_num(z_shift, False, 0, 0, 0)    # should be xp.nan_to_num
         except TypeError:
-            np.nan_to_num(z_shift, z_shift)
-
-        defocus = np.reshape(defocus, (-1, 1, 1))
-        z_shift = defocus * np.expand_dims(z_shift, axis=0)
+            np.nan_to_num(z_shift, z_shift)                     # should be xp.nan_to_num
         
+        defocus = np.reshape(defocus, (-1, 1, 1))               # should be xp.reshape
+        # if config.get_backend() == "numpy":
+        z_shift = defocus * np.expand_dims(z_shift, axis=0)
+        # else:
+        #     z_shift = defocus * torch.unsqueeze(z_shift, dim=0)
+
         if include_aberration:
             pupil = self.pupil
             if isinstance(pupil, Feature):
 
                 pupil_function = pupil(pupil_function)
 
-            elif isinstance(pupil, np.ndarray):
+            elif isinstance(pupil, np.ndarray) or torch.is_tensor(pupil):
                 pupil_function *= pupil
 
-        pupil_functions = pupil_function * np.exp(1j * z_shift)
+        pupil_functions = pupil_function * np.exp(1j * z_shift)     # should be xp.exp
 
         return pupil_functions
 

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -702,8 +702,9 @@ class Optics(Feature):
         refractive_index_medium: float,
         include_aberration: bool = True,
         defocus: float | ArrayLike[float] = 0,
+        **kwargs: Any,
     ) -> NDArray | torch.Tensor:
-        """Calculate the pupil function at different focal points.
+        """Calculate the complex pupil function at one or more focal points.
 
         Parameters
         ----------
@@ -716,16 +717,23 @@ class Optics(Feature):
         refractive_index_medium: float
             The refractive index of the medium.
         include_aberration: bool
-            If True, the aberration is included in the pupil function. Default is `True`.
+            If True, the aberration is included in the pupil function. Default
+            is `True`.
         defocus: float or list[float]
             The defocus of the system. If a list is given, the pupil is
-            calculated for each focal point. Defocus is given in meters. Default is `0`.
+            calculated for each focal point. Defocus is given in meters.
+            Default is `0`.
 
         Returns
         -------
         pupil: array_like[complex]
             The complex pupil function(s) at the specified defocus positions.
             Shape is (z, y, x).
+
+        Notes
+        -----
+        The backend (NumPy or PyTorch) is determined by `self.get_backend()`
+        and can be switched using the global backend configuration.
 
         Examples
         --------
@@ -744,7 +752,7 @@ class Optics(Feature):
 
         Calculating the pupil function with a PyTorch backend:
         >>> from deeptrack.backend import config
-        >>> config.set_backend('torch')
+        >>> config.set_backend("torch")
         >>>
         >>> optics = dt.Optics()
         >>> pupil = optics._pupil(
@@ -758,7 +766,7 @@ class Optics(Feature):
 
         """
 
-        # Calculates the pupil at each z-position in defocus.
+        # Calculate the pupil at each z-position in defocus.
         voxel_size = get_active_voxel_size()
 
         if self.get_backend() == "numpy":

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -407,21 +407,21 @@ class Optics(Feature):
     magnification: float, optional
         Magnification of the optical system, by default 10.
     resolution: float or array_like[float], optional
-        Distance between pixels in the camera (meters). A third value can 
+        Distance between pixels in the camera (meters). A third value can
         define the resolution in the z-direction, by default 1e-6.
     refractive_index_medium: float, optional
         Refractive index of the medium, by default 1.33.
     padding: array_like[int, int, int, int], optional
-        Padding applied to the sample volume to avoid edge effects, 
+        Padding applied to the sample volume to avoid edge effects,
         by default (10, 10, 10, 10).
     output_region: array_like[int, int, int, int], optional
-        Region of the image to output (x, y, width, height). If None, the 
+        Region of the image to output (x, y, width, height). If None, the
         entire image is returned, by default (0, 0, 128, 128).
     pupil: Feature, optional
         Feature-set resolving the pupil function at focus. By default, no pupil
         is applied.
     illumination: Feature, optional
-        Feature-set resolving the illumination source. By default, no specific 
+        Feature-set resolving the illumination source. By default, no specific
         illumination is applied.
     upscale: int, optional
         Scaling factor for the resolution of the optical system, by default 1.
@@ -461,9 +461,23 @@ class Optics(Feature):
     -------
     `_process_properties(propertydict: dict[str, Any]) -> dict[str, Any]`
         Processes and validates the input properties.
-    `_pupil(shape:  array_like[int, int], NA: float, wavelength: float, refractive_index_medium: float, include_aberration: bool, defocus: float, **kwargs: Any) -> array_like[complex]`
+    `_pupil(
+        shape: array_like[int, int],
+        NA: float,
+        wavelength: float,
+        refractive_index_medium: float,
+        include_aberration: bool,
+        defocus: float,
+        **kwargs: Any,
+    ) -> array_like[complex]`
         Calculates the pupil function at different focal points.
-    `_pad_volume(volume: array_like[complex], limits: array_like[int, int], padding: array_like[int], output_region: array_like[int], **kwargs: Any) -> tuple`
+    `_pad_volume(
+        volume: array_like[complex],
+        limits: array_like[int, int],
+        padding: array_like[int],
+        output_region: array_like[int],
+        **kwargs: Any,
+    ) -> tuple`
         Pads the volume with zeros to avoid edge effects.
     `__call__(sample: Feature, **kwargs: Any) -> Microscope`
         Creates a Microscope instance with the given sample and optics.
@@ -853,16 +867,24 @@ class Optics(Feature):
 
         # Replace None entries with current limit
         output_region[0] = (
-            output_region[0] if not output_region[0] is None else new_limits[0, 0]
+            output_region[0]
+            if not output_region[0] is None
+            else new_limits[0, 0]
         )
         output_region[1] = (
-            output_region[1] if not output_region[1] is None else new_limits[0, 1]
+            output_region[1]
+            if not output_region[1] is None
+            else new_limits[0, 1]
         )
         output_region[2] = (
-            output_region[2] if not output_region[2] is None else new_limits[1, 0]
+            output_region[2]
+            if not output_region[2] is None
+            else new_limits[1, 0]
         )
         output_region[3] = (
-            output_region[3] if not output_region[3] is None else new_limits[1, 1]
+            output_region[3]
+            if not output_region[3] is None
+            else new_limits[1, 1]
         )
 
         for i in range(2):

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -798,23 +798,37 @@ class Optics(Feature):
 
         if self.get_backend() == "numpy":
             RHO = (W**2 + H**2).astype(complex)
-            pupil_function = (RHO < 1) + 0.0j
+            pupil_function = Image((RHO < 1) + 0.0j, copy=False)
+
+            # Defocus
+            z_shift = Image(
+                2
+                * np.pi
+                * refractive_index_medium
+                / wavelength
+                * voxel_size[2]
+                * np.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO),
+                copy=False,
+            )
+
+            z_shift._value[z_shift._value.imag != 0] = 0
+
         else:
             RHO = W**2 + H**2
             pupil_function = (RHO < 1).to(dtype=torch.complex128) + 0.0j
             RHO = RHO.to(dtype=torch.complex128)
 
-        # Defocus
-        z_shift = (
-            2
-            * xp.pi
-            * refractive_index_medium
-            / wavelength
-            * voxel_size[2]
-            * xp.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO)
-        )
+            # Defocus
+            z_shift = (
+                2
+                * xp.pi
+                * refractive_index_medium
+                / wavelength
+                * voxel_size[2]
+                * xp.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO)
+            )
 
-        z_shift[z_shift.imag != 0] = 0
+            z_shift[z_shift.imag != 0] = 0
 
         try:
             z_shift = xp.nan_to_num(z_shift, nan=0.0, posinf=None, neginf=None)

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -140,9 +140,12 @@ from pint import Quantity
 from typing import Any
 import warnings
 
+import array_api_compat as apc
 import numpy as np
+from numpy.typing import NDArray
 from scipy.ndimage import convolve
 
+from deeptrack.backend import config, TORCH_AVAILABLE, xp
 from deeptrack.backend.units import (
     ConversionTable,
     create_context,
@@ -158,6 +161,8 @@ from deeptrack.types import ArrayLike, PropertyLike
 from deeptrack import image
 from deeptrack import units_registry as u
 
+if TORCH_AVAILABLE:
+    import torch
 
 #TODO ***??*** revise Microscope - torch, typing, docstring, unit test
 class Microscope(StructuralFeature):
@@ -1007,7 +1012,11 @@ class Fluorescence(Optics):
 
     Methods
     -------
-    `get(illuminated_volume: array_like[complex], limits: array_like[int, int], **kwargs: Any) -> Image`
+    `get(
+        illuminated_volume: array_like[complex],
+        limits: array_like[int, int],
+        **kwargs: Any,
+    ) -> Image`
         Simulates the imaging process using a fluorescence microscope.
 
     Examples
@@ -1087,7 +1096,8 @@ class Fluorescence(Optics):
 
         # Extract indexes of the output region
         pad = kwargs.get("padding", (0, 0, 0, 0))
-        output_region = np.array(kwargs.get("output_region", (None, None, None, None)))
+        # output_region = np.array(kwargs.get("output_region", (None, None, None, None)))
+        output_region = list(kwargs.get("output_region", (None, None, None, None)))
 
         # Calculate the how much to crop from the volume
         output_region[0] = (
@@ -1118,20 +1128,34 @@ class Fluorescence(Optics):
         ]
         z_limits = limits[2, :]
 
-        output_image = Image(
-            np.zeros((*padded_volume.shape[0:2], 1)), copy=False
-        )
+        if self.get_backend() == "numpy":
+            output_image = Image(
+                np.zeros((*padded_volume.shape[0:2], 1)), copy=False
+            )
+        elif self.get_backend() == "torch":
+            output_image = torch.zeros((*padded_volume.shape[0:2], 1))
+        else:
+            raise ValueError(f"Unsupported backend: {self.get_backend()}")
 
         index_iterator = range(padded_volume.shape[2])
 
         # Find planes that are not empty for optimization
-        z_iterator = np.linspace(
-            z_limits[0],
-            z_limits[1],
-            num=padded_volume.shape[2],
-            endpoint=False,
-        )
-        zero_plane = np.all(padded_volume == 0, axis=(0, 1), keepdims=False)
+        if self.get_backend() == "torch":
+            z_iterator = torch.linspace(
+                z_limits[0],
+                z_limits[1],
+                steps=padded_volume.shape[2] + 1,
+            )[:-1]                                  # exclude endpoint
+            zero_plane = torch.all(padded_volume == 0, dim=(0, 1))
+        else:
+            z_iterator = np.linspace(
+                z_limits[0],
+                z_limits[1],
+                num=padded_volume.shape[2],
+                endpoint=False,
+            )
+            zero_plane = np.all(padded_volume == 0, axis=(0, 1), keepdims=False)
+
         z_values = z_iterator[~zero_plane]
 
         # Further pad image to speed up fft (multiples of 2 and 3)

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -758,7 +758,7 @@ class Optics(Feature):
             R = NA / wavelength * np.array(voxel_size)[:2]
 
         elif self.get_backend() == "torch":
-            shape = torch.tensor(shape)
+            shape = torch.tensor(shape, dtype=torch.float64)
 
             # Pupil radius
             R = NA / wavelength * torch.tensor(voxel_size)[:2]
@@ -771,10 +771,10 @@ class Optics(Feature):
         y_radius = R[1] * shape[1]
 
         x = (
-            xp.linspace(-(shape[0] / 2), shape[0] / 2 - 1, shape[0])
+            xp.linspace(-(shape[0] / 2), shape[0] / 2 - 1, int(shape[0]))
         ) / x_radius + 1e-8
         y = (
-            xp.linspace(-(shape[1] / 2), shape[1] / 2 - 1, shape[1])
+            xp.linspace(-(shape[1] / 2), shape[1] / 2 - 1, int(shape[1]))
         ) / y_radius + 1e-8
 
         W, H = xp.meshgrid(y, x, indexing='xy')
@@ -784,8 +784,8 @@ class Optics(Feature):
             pupil_function = (RHO < 1) + 0.0j
         else:
             RHO = (W ** 2 + H ** 2)
-            pupil_function = (RHO < 1).to(dtype=torch.complex64) + 0.0j
-            RHO = RHO.to(dtype=torch.complex64)
+            pupil_function = (RHO < 1).to(dtype=torch.complex128) + 0.0j
+            RHO = RHO.to(dtype=torch.complex128)
 
         # Defocus
         z_shift = (

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -891,14 +891,17 @@ class Optics(Feature):
         [ 0, 10]])
         
         """
-        
-        if limits is None:
-            limits = xp.zeros((3, 2))
 
         if apc.is_torch_array(volume):
+            if limits is None:
+                limits = torch.zeros(3, 2)
+
             new_limits = limits.clone()
 
         else:
+            if limits is None:
+                limits = np.zeros((3, 2))
+
             new_limits = np.array(limits)
 
         if output_region is None:
@@ -929,11 +932,23 @@ class Optics(Feature):
 
         # Update the new limits based on padding and output region
         for i in range(2):
-            new_limits[i, 0] = min(new_limits[i, 0], output_region[i] - padding[i])
-            new_limits[i, 1] = max(new_limits[i, 1], output_region[i + 2] + padding[i + 2])
+            new_limits[i, 0] = min(
+                new_limits[i, 0], output_region[i] - padding[i]
+            )
+            new_limits[i, 1] = max(
+                new_limits[i, 1], output_region[i + 2] + padding[i + 2]
+            )
 
         # Determine shape for the new volume
-        new_volume = xp.zeros(tuple(new_limits[:, 1] - new_limits[:, 0]), dtype=volume.dtype)
+        if apc.is_torch_array(volume):
+            new_volume = torch.zeros(
+                tuple(new_limits[:, 1] - new_limits[:, 0]), dtype=volume.dtype
+            )
+        else:
+            new_volume = np.zeros(
+                np.diff(new_limits, axis=1)[:, 0].astype(np.int32),
+                dtype=complex,
+            )
 
         # Compute where to place the old volume in the new one
         old_region = (limits - new_limits)
@@ -950,6 +965,7 @@ class Optics(Feature):
             old_region[1, 0] : old_region[1, 0] + limits[1, 1] - limits[1, 0],
             old_region[2, 0] : old_region[2, 0] + limits[2, 1] - limits[2, 0],
         ] = volume
+        
         return new_volume, new_limits
 
     def __call__(

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -702,8 +702,7 @@ class Optics(Feature):
         refractive_index_medium: float,
         include_aberration: bool = True,
         defocus: float | ArrayLike[float] = 0,
-        **kwargs: Any,
-    ):
+    ) -> NDArray | torch.Tensor:
         """Calculate the pupil function at different focal points.
 
         Parameters
@@ -716,26 +715,23 @@ class Optics(Feature):
             The wavelength of the scattered light in meters.
         refractive_index_medium: float
             The refractive index of the medium.
-        voxel_size: array_like[float (, float, float)]
-            The distance between pixels in the camera. A third value can be
-            included to define the resolution in the z-direction.
         include_aberration: bool
-            If True, the aberration is included in the pupil function.
+            If True, the aberration is included in the pupil function. Default is `True`.
         defocus: float or list[float]
             The defocus of the system. If a list is given, the pupil is
-            calculated for each focal point. Defocus is given in meters.
+            calculated for each focal point. Defocus is given in meters. Default is `0`.
 
         Returns
         -------
         pupil: array_like[complex]
-            The pupil function. Shape is (z, y, x).
+            The complex pupil function(s) at the specified defocus positions.
+            Shape is (z, y, x).
 
         Examples
         --------
-        Calculating the pupil function:
-
         >>> import deeptrack as dt
 
+        Calculating the pupil function:
         >>> optics = dt.Optics()
         >>> pupil = optics._pupil(
         ...     shape=(128, 128),
@@ -743,8 +739,22 @@ class Optics(Feature):
         ...     wavelength=0.55e-6,
         ...     refractive_index_medium=1.33,
         ... )
-        >>> print(pupil.shape)
-        (1, 128, 128)
+        >>> print(pupil.shape, pupil.dtype)
+        (1, 128, 128) complex128
+
+        Calculating the pupil function with a PyTorch backend:
+        >>> from deeptrack.backend import config
+        >>> config.set_backend('torch')
+        >>>
+        >>> optics = dt.Optics()
+        >>> pupil = optics._pupil(
+        ...     shape=(128, 128),
+        ...     NA=0.8,
+        ...     wavelength=0.55e-6,
+        ...     refractive_index_medium=1.33,
+        ... )
+        >>> print(pupil.shape, pupil.dtype)
+        torch.Size([1, 128, 128]) torch.complex128
 
         """
 

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -751,20 +751,20 @@ class Optics(Feature):
         # Calculates the pupil at each z-position in defocus.
         voxel_size = get_active_voxel_size()
 
-        if config.get_backend() == "numpy":
+        if self.get_backend() == "numpy":
             shape = np.array(shape)
 
             # Pupil radius
             R = NA / wavelength * np.array(voxel_size)[:2]
 
-        elif config.get_backend() == "torch":
+        elif self.get_backend() == "torch":
             shape = torch.tensor(shape)
 
             # Pupil radius
             R = NA / wavelength * torch.tensor(voxel_size)[:2]
 
         else:
-            raise ValueError(f"Unsupported backend: {config.get_backend()}")
+            raise ValueError(f"Unsupported backend: {self.get_backend()}")
 
 
         x_radius = R[0] * shape[0]
@@ -778,37 +778,38 @@ class Optics(Feature):
         ) / y_radius + 1e-8
 
         W, H = xp.meshgrid(y, x, indexing='xy')
-        
-        if config.get_backend() == "numpy":
-            RHO = (W ** 2 + H ** 2).astype(complex)
-        else:
-            RHO = (W ** 2 + H ** 2).to(dtype=torch.complex64)
-            RHO = RHO.numpy()                                       # not to be kept, only to make it compatible with Image at the moment
 
-        pupil_function = Image((RHO < 1) + 0.0j, copy=False)        # what should we do about this?
+        if self.get_backend() == "numpy":
+            RHO = (W ** 2 + H ** 2).astype(complex)
+            pupil_function = (RHO < 1) + 0.0j
+        else:
+            RHO = (W ** 2 + H ** 2)
+            pupil_function = (RHO < 1).to(dtype=torch.complex64) + 0.0j
+            RHO = RHO.to(dtype=torch.complex64)
+
         # Defocus
-        z_shift = Image(
+        z_shift = (
             2
-            * np.pi                                     # should be xp.pi
+            * xp.pi
             * refractive_index_medium
             / wavelength
             * voxel_size[2]
-            * np.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO),   # should be xp.sqrt
-            copy=False,
+            * xp.sqrt(1 - (NA / refractive_index_medium) ** 2 * RHO)
         )
 
-        z_shift._value[z_shift._value.imag != 0] = 0
+        z_shift[z_shift.imag != 0] = 0
 
         try:
-            z_shift = np.nan_to_num(z_shift, False, 0, 0, 0)    # should be xp.nan_to_num
+            z_shift = xp.nan_to_num(z_shift, nan=0.0, posinf=None, neginf=None)
         except TypeError:
-            np.nan_to_num(z_shift, z_shift)                     # should be xp.nan_to_num
-        
-        defocus = np.reshape(defocus, (-1, 1, 1))               # should be xp.reshape
-        # if config.get_backend() == "numpy":
-        z_shift = defocus * np.expand_dims(z_shift, axis=0)
-        # else:
-        #     z_shift = defocus * torch.unsqueeze(z_shift, dim=0)
+            xp.nan_to_num(z_shift, z_shift)
+
+        if self.get_backend() == "numpy":
+            defocus = np.reshape(defocus, (-1, 1, 1))
+            z_shift = defocus * np.expand_dims(z_shift, axis=0)
+        else:
+            defocus = torch.reshape(torch.as_tensor(defocus), (-1, 1, 1))
+            z_shift = defocus * torch.unsqueeze(z_shift, dim=0)
 
         if include_aberration:
             pupil = self.pupil
@@ -819,7 +820,7 @@ class Optics(Feature):
             elif isinstance(pupil, np.ndarray) or torch.is_tensor(pupil):
                 pupil_function *= pupil
 
-        pupil_functions = pupil_function * np.exp(1j * z_shift)     # should be xp.exp
+        pupil_functions = pupil_function * xp.exp(1j * z_shift)
 
         return pupil_functions
 

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -766,7 +766,6 @@ class Optics(Feature):
         else:
             raise ValueError(f"Unsupported backend: {self.get_backend()}")
 
-
         x_radius = R[0] * shape[0]
         y_radius = R[1] * shape[1]
 
@@ -777,13 +776,13 @@ class Optics(Feature):
             xp.linspace(-(shape[1] / 2), shape[1] / 2 - 1, int(shape[1]))
         ) / y_radius + 1e-8
 
-        W, H = xp.meshgrid(y, x, indexing='xy')
+        W, H = xp.meshgrid(y, x, indexing="xy")
 
         if self.get_backend() == "numpy":
-            RHO = (W ** 2 + H ** 2).astype(complex)
+            RHO = (W**2 + H**2).astype(complex)
             pupil_function = (RHO < 1) + 0.0j
         else:
-            RHO = (W ** 2 + H ** 2)
+            RHO = W**2 + H**2
             pupil_function = (RHO < 1).to(dtype=torch.complex128) + 0.0j
             RHO = RHO.to(dtype=torch.complex128)
 

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -948,8 +948,8 @@ class Fluorescence(Optics):
     """Optical device for fluorescent imaging.
 
     The `Fluorescence` class simulates the imaging process in fluorescence
-    microscopy by creating a discretized volume where each pixel represents 
-    the intensity of light emitted by fluorophores in the sample. It extends 
+    microscopy by creating a discretized volume where each pixel represents
+    the intensity of light emitted by fluorophores in the sample. It extends
     the `Optics` class to include fluorescence-specific functionalities.
 
     Parameters
@@ -967,10 +967,10 @@ class Fluorescence(Optics):
     padding: array_like[int, int, int, int]
         Padding applied to the sample volume to reduce edge effects.
     output_region: array_like[int, int, int, int], optional
-        Region of the output image to extract (x, y, width, height). If None, 
+        Region of the output image to extract (x, y, width, height). If None,
         returns the full image.
     pupil: Feature, optional
-        A feature set defining the pupil function at focus. The input is 
+        A feature set defining the pupil function at focus. The input is
         the unaberrated pupil.
     illumination: Feature, optional
         A feature set defining the illumination source.
@@ -994,7 +994,7 @@ class Fluorescence(Optics):
         Padding applied to the sample volume to reduce edge effects.
     output_region: array_like[int, int, int, int]
         Region of the output image to extract (x, y, width, height).
-    voxel_size: function
+    voxel_size: function                                            # Do we want the user to be able to set the voxel size here? If so, we would have to modify the super().__init__ of Optics 
         Function returning the voxel size of the optical system.
     pixel_size: function
         Function returning the pixel size of the optical system.
@@ -1032,7 +1032,7 @@ class Fluorescence(Optics):
     ) -> Image:
         """Simulates the imaging process using a fluorescence microscope.
 
-        This method convolves the 3D illuminated volume with a pupil function 
+        This method convolves the 3D illuminated volume with a pupil function
         to generate a 2D image projection.
 
         Parameters
@@ -1070,14 +1070,14 @@ class Fluorescence(Optics):
         >>> limits = np.array([[0, 128], [0, 128], [0, 10]])
         >>> properties = optics.properties()
         >>> filtered_properties = {
-        ...     k: v for k, v in properties.items() 
-        ...     if k in {"padding", "output_region", "NA", 
+        ...     k: v for k, v in properties.items()
+        ...     if k in {"padding", "output_region", "NA",
         ...              "wavelength", "refractive_index_medium"}
         ... }
         >>> image = optics.get(volume, limits, **filtered_properties)
         >>> print(image.shape)
         (128, 128, 1)
-        
+
         """
 
         # Pad volume

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -844,11 +844,11 @@ class Optics(Feature):
 
         Examples
         --------
-        Padding a volume:
-
         >>> import deeptrack as dt
-        >>> import numpy as np
 
+        Padding a volume:        
+        >>> import numpy as np
+        >>>
         >>> volume = np.ones((10, 10, 10), dtype=complex)
         >>> limits = np.array([[0, 10], [0, 10], [0, 10]])
         >>> optics = dt.Optics()
@@ -868,9 +868,7 @@ class Optics(Feature):
 
         Padding a volume using PyTorch: 
         >>> import torch
-        >>> from deeptrack.backend import config
-        >>> config.set_backend("torch")
-
+        >>>
         >>> volume = torch.ones(10, 10, 10, dtype=complex)
         >>> limits = torch.tensor([[0, 10], [0, 10], [0, 10]])
         >>> optics = dt.Optics()

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -142,6 +142,7 @@ import warnings
 
 import array_api_compat as apc
 import numpy as np
+from numpy.typing import NDArray
 from scipy.ndimage import convolve
 
 from deeptrack.backend import config, TORCH_AVAILABLE, xp
@@ -813,18 +814,18 @@ class Optics(Feature):
 
     def _pad_volume(
         self: Optics,
-        volume: ArrayLike[complex],
+        volume: NDArray | torch.Tensor,
         limits: ArrayLike[int] = None,
         padding: ArrayLike[int] = None,
         output_region: ArrayLike[int] = None,
         **kwargs: Any,
     ) -> tuple:
-        """Pad the volume with zeros to avoid edge effects.
+        """Pad the input volume with zeros to avoid edge effects.
 
         Parameters
         ----------
-        volume: array_like[complex]
-            The volume to pad.
+        volume: NDArray | torch.Tensor
+            The complex-valued volume to pad.
         limits: array_like[int, int]
             The limits of the volume.
         padding: array_like[int]
@@ -836,8 +837,8 @@ class Optics(Feature):
 
         Returns
         -------
-        new_volume: array_like[complex]
-            The padded volume.
+        new_volume: NDArray | torch.Tensor
+            The padded, complex valued volume.
         new_limits: array_like[int, int]
             The new limits of the volume.
 
@@ -965,7 +966,7 @@ class Optics(Feature):
             old_region[1, 0] : old_region[1, 0] + limits[1, 1] - limits[1, 0],
             old_region[2, 0] : old_region[2, 0] + limits[2, 1] - limits[2, 0],
         ] = volume
-        
+
         return new_volume, new_limits
 
     def __call__(

--- a/deeptrack/optics.py
+++ b/deeptrack/optics.py
@@ -140,9 +140,11 @@ from pint import Quantity
 from typing import Any
 import warnings
 
+import array_api_compat as apc
 import numpy as np
 from scipy.ndimage import convolve
 
+from deeptrack.backend import config, TORCH_AVAILABLE, xp
 from deeptrack.backend.units import (
     ConversionTable,
     create_context,
@@ -157,6 +159,9 @@ from deeptrack.types import ArrayLike, PropertyLike
 
 from deeptrack import image
 from deeptrack import units_registry as u
+
+if TORCH_AVAILABLE:
+    import torch
 
 
 #TODO ***??*** revise Microscope - torch, typing, docstring, unit test
@@ -814,7 +819,7 @@ class Optics(Feature):
         output_region: ArrayLike[int] = None,
         **kwargs: Any,
     ) -> tuple:
-        """Pads the volume with zeros to avoid edge effects.
+        """Pad the volume with zeros to avoid edge effects.
 
         Parameters
         ----------
@@ -847,23 +852,58 @@ class Optics(Feature):
         >>> limits = np.array([[0, 10], [0, 10], [0, 10]])
         >>> optics = dt.Optics()
         >>> padded_volume, new_limits = optics._pad_volume(
-        ...     volume, limits=limits, padding=[5, 5, 5, 5],
+        ...     volume,
+        ...     limits=limits,
+        ...     padding=[5, 5, 5, 5],
         ...     output_region=[0, 0, 10, 10],
         ... )
         >>> print(padded_volume.shape)
         (20, 20, 10)
+
         >>> print(new_limits)
         [[-5 15]
          [-5 15]
          [ 0 10]]
+
+        Padding a volume using PyTorch: 
+        >>> import torch
+        >>> from deeptrack.backend import config
+        >>> config.set_backend("torch")
+
+        >>> volume = torch.ones(10, 10, 10, dtype=complex)
+        >>> limits = torch.tensor([[0, 10], [0, 10], [0, 10]])
+        >>> optics = dt.Optics()
+        >>> padded_volume, new_limits = optics._pad_volume(
+        ...     volume,
+        ...     limits=limits,
+        ...     padding=[5, 5, 5, 5],
+        ...     output_region=[0, 0, 10, 10],
+        ... )
+        >>> print(padded_volume.shape)
+        torch.Size([20, 20, 10])
+
+        >>> print(padded_volume.dtype)
+        torch.complex128
+
+        >>> print(new_limits)
+        tensor([[-5, 15],
+        [-5, 15],
+        [ 0, 10]])
         
         """
         
         if limits is None:
-            limits = np.zeros((3, 2))
+            limits = xp.zeros((3, 2))
 
-        new_limits = np.array(limits)
-        output_region = np.array(output_region)
+        if apc.is_torch_array(volume):
+            new_limits = limits.clone()
+
+        else:
+            new_limits = np.array(limits)
+
+        if output_region is None:
+            output_region = [None] * 4
+        output_region = list(output_region)
 
         # Replace None entries with current limit
         output_region[0] = (
@@ -887,23 +927,24 @@ class Optics(Feature):
             else new_limits[1, 1]
         )
 
+        # Update the new limits based on padding and output region
         for i in range(2):
-            new_limits[i, :] = (
-                np.min([new_limits[i, 0], output_region[i] - padding[i]]),
-                np.max(
-                    [
-                        new_limits[i, 1],
-                        output_region[i + 2] + padding[i + 2],
-                    ]
-                ),
-            )
-        new_volume = np.zeros(
-            np.diff(new_limits, axis=1)[:, 0].astype(np.int32),
-            dtype=complex,
-        )
+            new_limits[i, 0] = min(new_limits[i, 0], output_region[i] - padding[i])
+            new_limits[i, 1] = max(new_limits[i, 1], output_region[i + 2] + padding[i + 2])
 
-        old_region = (limits - new_limits).astype(np.int32)
-        limits = limits.astype(np.int32)
+        # Determine shape for the new volume
+        new_volume = xp.zeros(tuple(new_limits[:, 1] - new_limits[:, 0]), dtype=volume.dtype)
+
+        # Compute where to place the old volume in the new one
+        old_region = (limits - new_limits)
+        
+        if apc.is_torch_array(volume):
+            old_region = old_region.to(torch.int32)
+            limits = limits.to(torch.int32)
+        else:
+            old_region = old_region.astype(np.int32)
+            limits = limits.astype(np.int32)
+
         new_volume[
             old_region[0, 0] : old_region[0, 0] + limits[0, 1] - limits[0, 0],
             old_region[1, 0] : old_region[1, 0] + limits[1, 1] - limits[1, 0],

--- a/deeptrack/tests/test_image.py
+++ b/deeptrack/tests/test_image.py
@@ -12,7 +12,10 @@ import unittest
 
 import numpy as np
 
-from deeptrack import features, image
+from deeptrack import features, image, TORCH_AVAILABLE
+
+if TORCH_AVAILABLE:
+    import torch
 
 
 class TestImage(unittest.TestCase):
@@ -389,6 +392,7 @@ class TestImage(unittest.TestCase):
 
     def test_pad_image_to_fft(self):
 
+        # Test with dt.Image
         input_image = image.Image(np.zeros((7, 25)))
         padded_image = image.pad_image_to_fft(input_image)
         self.assertEqual(padded_image.shape, (8, 27))
@@ -400,6 +404,33 @@ class TestImage(unittest.TestCase):
         input_image = image.Image(np.zeros((300, 400)))
         padded_image = image.pad_image_to_fft(input_image)
         self.assertEqual(padded_image.shape, (324, 432))
+
+        # Test with NumPy array
+        input_image = np.ones((7, 13))
+        padded_image = image.pad_image_to_fft(input_image)
+        self.assertEqual(padded_image.shape, (8, 16))
+
+        input_image = np.ones((5,))
+        padded_image = image.pad_image_to_fft(input_image, axes=(0,))
+        self.assertEqual(padded_image.shape, (6,))
+
+        ### Test with PyTorch tensor (if available)
+        if TORCH_AVAILABLE:
+            input_image = torch.ones(3, 5)
+            padded_image = image.pad_image_to_fft(input_image)
+            self.assertEqual(padded_image.shape, (3, 6))
+            self.assertIsInstance(padded_image, torch.Tensor)
+
+            input_image = torch.ones(5, 7, 11, 13)
+            padded_image = image.pad_image_to_fft(input_image, axes=(0, 1, 3))
+            padded_image_np = image.pad_image_to_fft(
+                input_image.numpy(), axes=(0, 1, 3)
+            )
+            self.assertEqual(padded_image.shape, (6, 8, 11, 16))
+            self.assertIsInstance(padded_image, torch.Tensor)
+            np.testing.assert_allclose(
+                padded_image.numpy(), padded_image_np, atol=1e-6
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When only changing the backend of the feature:

`optics = dt.Optics()`
`optics.torch()`
`pupil = optics._pupil(...`

`xp` is still the same as `np`. But when changing the entire backend:

`from deeptrack.backend import config`
`config.set_backend('torch')`
`optics = dt.Optics()`
`pupil = optics._pupil(...`

both the backend of the feature and the xp is changed, so that the output becomes the desired one. That is the reason for doing it like this in the example.