### PR TITLE
al/bf-mie-fix

### DIFF
--- a/deeptrack/optical/optics.py
+++ b/deeptrack/optical/optics.py
@@ -3,7 +3,7 @@
 This module provides features for simulating optical image formation from
 sample representations such as `ScatteredVolume` and `ScatteredField`.
 It includes a high-level `Microscope` wrapper, a base `Optics` class, and
-specialized optical systems for coherent and incoherent imaging.
+specialized optical systems for coherent and incoherent imaging.f
 
 Key Features
 ------------
@@ -2001,8 +2001,8 @@ class Brightfield(Optics):
 
                     field_arrays.append(arr)
 
-                field_arrays = xp.asarray(field_arrays)
-                field = xp.sum(field_arrays, axis=0)
+                field = xp.sum(xp.stack(field_arrays, axis=0), axis=0)
+              
                 light_in_focus += field[..., 0]
             shifted_pupil = xp.fft.fftshift(pupils[-1])
             light_in_focus = light_in_focus * shifted_pupil

--- a/deeptrack/optical/optics.py
+++ b/deeptrack/optical/optics.py
@@ -3,7 +3,7 @@
 This module provides features for simulating optical image formation from
 sample representations such as `ScatteredVolume` and `ScatteredField`.
 It includes a high-level `Microscope` wrapper, a base `Optics` class, and
-specialized optical systems for coherent and incoherent imaging
+specialized optical systems for coherent and incoherent imaging.
 
 Key Features
 ------------

--- a/deeptrack/optical/optics.py
+++ b/deeptrack/optical/optics.py
@@ -3,7 +3,7 @@
 This module provides features for simulating optical image formation from
 sample representations such as `ScatteredVolume` and `ScatteredField`.
 It includes a high-level `Microscope` wrapper, a base `Optics` class, and
-specialized optical systems for coherent and incoherent imaging.f
+specialized optical systems for coherent and incoherent imaging
 
 Key Features
 ------------

--- a/deeptrack/optical/optics.py
+++ b/deeptrack/optical/optics.py
@@ -2001,6 +2001,7 @@ class Brightfield(Optics):
 
                     field_arrays.append(arr)
 
+                field_arrays = xp.asarray(field_arrays)
                 field = xp.sum(field_arrays, axis=0)
                 light_in_focus += field[..., 0]
             shifted_pupil = xp.fft.fftshift(pupils[-1])


### PR DESCRIPTION
Adds a line to convert a list to an xp-array when resolving fields for Mie scatterers.

line 2002 in `optics.py`:
```python
...
     field_arrays.append(arr)

field = xp.sum(field_arrays, axis=0)
```
Will fail when attempting `xp.sum` due to `field_arrays` being a list.

Adding an intermediate conversion:
```python
...
     field_arrays.append(arr)

field_arrays = xp.asarray(field_arrays)
field = xp.sum(field_arrays, axis=0)
```
Resolves this.