### PR TITLE
fix z-coeffs skip when 0 for torch

### DIFF
--- a/deeptrack/optical/aberrations.py
+++ b/deeptrack/optical/aberrations.py
@@ -506,7 +506,9 @@ class Zernike(Aberration):
         Z = 0 * rho
 
         for n, m, coefficient in zip(n_list, m_list, coefficients):
-            if (n - abs(m)) % 2 or coefficient == 0:
+            if (n - abs(m)) % 2:
+                continue
+            if not (TORCH_AVAILABLE and torch.is_tensor(coefficient)) and coefficient == 0:
                 continue
 
             R = 0 * rho


### PR DESCRIPTION
This fixes torch autograd for trainable Zernike coefficients initialized at zero.
The current Zernike loop skips any coefficient where `coefficient == 0`. For a torch tensor/Parameter it removes the coefficient from the computation graph. 

Proposed change:

```
  if (n - abs(m)) % 2:
      continue
  if not (TORCH_AVAILABLE and torch.is_tensor(coefficient)) and coefficient == 0:
      continue
```