### PR TITLE
Review DTEx211 MNIST

### DIFF
--- a/tutorials/2-examples/DTEx211_MNIST.ipynb
+++ b/tutorials/2-examples/DTEx211_MNIST.ipynb
@@ -984,11 +984,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Finally, you can proceed with the training.\n",
-    "\n",
-    "The training process can be quite slow (several hours on GPU) because the augmented images are used only once during the training. You can speed it up by reducing the numebr of epochs and decreasing the `replace` parameter used in the dataset."
-   ]
+   "source": "Finally, you can proceed with the training.\n\nThe training process can be slow on some machines because the augmented images are regenerated every time they are accessed, rather than precomputed and reused. You can reduce `max_epochs` to shorten the total training time, decrease the `replace` parameter used in the dataset to trade off augmentation diversity for speed, or increase `num_workers` in the data loaders above to parallelize data loading and augmentation across CPU cores."
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
- The description in the cell suggesting that it might take hours to train in a single GPU is deprecated. In the newer version of DeepTrack2 the gc.Collect bug that was slowing it down was fixed, so now it only takes a few minutes.
- Added the link to the README