### PR TITLE
docs: fix two broken tutorial notebook links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Here you find a series of notebooks providing an overview of the core features o
 
   Creating custom scatterers of arbitrary shapes.
 
-- DTGS172  **[Simulating Bacteria](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS172_custom_scatterers_bacteria.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS172_custom_scatterers_bacteria.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
+- DTGS172  **[Simulating Bacteria](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS172_bacteria.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/1-getting-started/DTGS172_bacteria.ipynb"><img src="https://colab.research.google.com/assets/colab-badge.svg"></a>
 
   Creating custom scatterers in the shape of bacteria.
 
@@ -232,7 +232,7 @@ This section provides a list of advanced tutorials. The primary focus of these t
 
 - DTAT353 **[deeptrack.statistics](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT353_statistics.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT353_statistics.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-- DTAT355 **[deeptrack.types](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT_387_types.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
+- DTAT355 **[deeptrack.types](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT355_types.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT355_types.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 - DTAT357 **[deeptrack.elementwise](https://github.com/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT357_elementwise.ipynb)** <a href="https://colab.research.google.com/github/DeepTrackAI/DeepTrack2/blob/develop/tutorials/3-advanced-topics/DTAT357_elementwise.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 


### PR DESCRIPTION
Two tutorial links in the README point at notebook filenames that don't exist on `develop`, so both the GitHub link and the "Open in Colab" badge 404.

| README entry | Linked path | Actual path on `develop` |
|---|---|---|
| DTGS172 — Simulating Bacteria | `tutorials/1-getting-started/DTGS172_custom_scatterers_bacteria.ipynb` | `tutorials/1-getting-started/DTGS172_bacteria.ipynb` |
| DTAT355 — deeptrack.types | `tutorials/3-advanced-topics/DTAT_387_types.ipynb` | `tutorials/3-advanced-topics/DTAT355_types.ipynb` |

Both corrections are unambiguous: the `DTGS172_` and `DTAT355` prefixes in the README's own entry labels match exactly one notebook each in the tree, and no notebook by either linked name exists on any branch.

Each line carries the path twice (the markdown link and the Colab badge `href`), so four occurrences were updated in total. README-only change.
